### PR TITLE
Support Empty Env List and Return Stable Values

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -344,8 +344,14 @@ resource "null_resource" "env_vars" {
   count = 50
 
   triggers {
-    key   = "${count.index < length(keys(var.env_vars)) ?                      element(concat(keys(var.env_vars),list("")), count.index)                         : format(var.env_default_key, count.index+1)}"
-    value = "${count.index < length(keys(var.env_vars)) ? lookup(var.env_vars, element(concat(keys(var.env_vars),list("")), count.index), var.env_default_value) : var.env_default_value} "
+    key = "${count.index < length(var.env_vars) ?
+                    element(concat(keys(var.env_vars),list("")), count.index) :
+                    format(var.env_default_key, count.index+1)
+                 }"
+
+    value = "${count.index < length(var.env_vars) ?
+                    lookup(var.env_vars, element(concat(keys(var.env_vars),list("")), count.index), var.env_default_value) :
+                    var.env_default_value}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -342,8 +342,8 @@ resource "null_resource" "env_vars" {
   count = 50
 
   triggers {
-    key   = "${count.index >= length(keys(var.env_vars)) ? format(var.env_default_key, count.index+1) : element(keys(var.env_vars), count.index)}"
-    value = "${count.index >= length(keys(var.env_vars)) ? var.env_default_value : lookup(var.env_vars, element(keys(var.env_vars), count.index))}"
+    key   = "${count.index < length(keys(var.env_vars)) ?                      element(keys(var.env_vars), count.index)  : format(var.env_default_key, count.index+1)}"
+    value = "${count.index < length(keys(var.env_vars)) ? lookup(var.env_vars, element(keys(var.env_vars), count.index)) : var.env_default_value} "
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -345,13 +345,14 @@ resource "null_resource" "env_vars" {
 
   triggers {
     key = "${count.index < length(var.env_vars) ?
-                    element(concat(keys(var.env_vars),list("")), count.index) :
-                    format(var.env_default_key, count.index+1)
-                 }"
+                        element(concat(keys(var.env_vars),list("")), count.index) :
+                        format(var.env_default_key, count.index+1)
+               }"
 
     value = "${count.index < length(var.env_vars) ?
-                    lookup(var.env_vars, element(concat(keys(var.env_vars),list("")), count.index), var.env_default_value) :
-                    var.env_default_value}"
+                        lookup(var.env_vars, element(concat(keys(var.env_vars),list("")), count.index), var.env_default_value) :
+                        var.env_default_value
+                 }"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -342,8 +342,8 @@ resource "null_resource" "env_vars" {
   count = 50
 
   triggers {
-    key   = "${count.index < length(keys(var.env_vars)) ?                      element(keys(var.env_vars), count.index)  : format(var.env_default_key, count.index+1)}"
-    value = "${count.index < length(keys(var.env_vars)) ? lookup(var.env_vars, element(keys(var.env_vars), count.index)) : var.env_default_value} "
+    key   = "${count.index < length(keys(var.env_vars)) ?                      element(concat(keys(var.env_vars),list("")), count.index)                         : format(var.env_default_key, count.index+1)}"
+    value = "${count.index < length(keys(var.env_vars)) ? lookup(var.env_vars, element(concat(keys(var.env_vars),list("")), count.index), var.env_default_value) : var.env_default_value} "
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,9 @@ resource "aws_ssm_activation" "ec2" {
 }
 
 #
+
 # Other stuff
+
 #
 
 data "aws_iam_policy_document" "default" {
@@ -348,8 +350,11 @@ resource "null_resource" "env_vars" {
 }
 
 #
+
 # Full list of options:
+
 # http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elasticbeanstalkmanagedactionsplatformupdate
+
 #
 
 resource "aws_elastic_beanstalk_environment" "default" {

--- a/main.tf
+++ b/main.tf
@@ -343,7 +343,7 @@ resource "null_resource" "env_vars" {
 
   triggers {
     key   = "${count.index >= length(keys(var.env_vars)) ? format(var.env_default_key, count.index+1) : element(keys(var.env_vars), count.index)}"
-    value = "${count.index >= length(values(var.env_vars)) ? var.env_default_value : element(values(var.env_vars), count.index)}"
+    value = "${count.index >= length(keys(var.env_vars)) ? var.env_default_value : lookup(var.env_vars, element(keys(var.env_vars), count.index))}"
   }
 }
 


### PR DESCRIPTION
## What
* Fix element() for empty list workaround
* Fix key-value association

## Why
* For empty env_vars there was error `element()` may not be used with an empty list in:
https://github.com/hashicorp/terraform/issues/9858
* `keys()` return list sorted in lexical order, but `values()` in order as defined in map.
So to make key-value association we need to use `lookup()`