### PR TITLE
Add `Application Load Balancer` health check settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -570,7 +570,6 @@ resource "aws_elastic_beanstalk_environment" "default" {
     name      = "Application Healthcheck URL"
     value     = "HTTP:80${var.healthcheck_url}"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:environment"
     name      = "LoadBalancerType"
@@ -881,6 +880,25 @@ resource "aws_elastic_beanstalk_environment" "default" {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "${null_resource.env_vars.49.triggers.key}"
     value     = "${null_resource.env_vars.49.triggers.value}"
+  }
+  ###===================== Application Load Balancer Health check settings =====================================================###
+  # The Application Load Balancer health check does not take into account the Elastic Beanstalk health check path
+  # http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-applicationloadbalancer.html
+  # http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-applicationloadbalancer.html#alb-default-process.config
+  setting {
+    namespace = "aws:elasticbeanstalk:environment:process:default"
+    name      = "HealthCheckPath"
+    value     = "${var.healthcheck_url}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:environment:process:default"
+    name      = "Port"
+    value     = "80"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:environment:process:default"
+    name      = "Protocol"
+    value     = "HTTP"
   }
   depends_on = ["aws_security_group.default"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,6 @@ variable "http_listener_enabled" {
   default = false
 }
 
-
 variable "zone_id" {
   default = ""
 }


### PR DESCRIPTION
## What

* Added `Application Load Balancer` health check settings in namespace `aws:elasticbeanstalk:environment:process:default`


## Why

* The `ALB` health check does not take into account the `Elastic Beanstalk` health check path

## References

* http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-applicationloadbalancer.html
* http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-applicationloadbalancer.html#alb-default-process.config
* http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elasticbeanstalkapplication
