### PR TITLE
Add `AmazonEC2ContainerRegistryReadOnly` policy to provide read-only access to `ECR` repositories

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,13 @@ resource "aws_iam_role_policy_attachment" "ssm-automation" {
   }
 }
 
+# http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_docker.container.console.html
+# http://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html#AmazonEC2ContainerRegistryReadOnly
+resource "aws_iam_role_policy_attachment" "ecr-readonly" {
+  role       = "${aws_iam_role.ec2.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
 resource "aws_ssm_activation" "ec2" {
   name               = "${module.label.id}"
   iam_role           = "${aws_iam_role.ec2.id}"


### PR DESCRIPTION
## What

* Add `AmazonEC2ContainerRegistryReadOnly` managed policy to `EB`


## Why

* To provide read-only access to all Amazon ECR repositories in the account

* When `CodePipeline` builds and pushes `Docker` images to `ECR` and then deploys the file `Dockerrun.aws.json` to `EB` with the `ECR` repo URL specified, `EB` needs permissions to pull the `Docker` image from the ECR repo to deploy it to `EC2` instances


## References

* http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_docker.container.console.html
* http://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html#AmazonEC2ContainerRegistryReadOnly
