### PR TITLE
Add permissions to the instance profile to start/stop EC2 instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -155,12 +155,22 @@ data "aws_iam_policy_document" "default" {
       "ec2:AssociateAddress",
       "ec2:DescribeAddresses",
       "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSpotInstanceRequests",
+      "ec2:CancelSpotInstanceRequests",
+      "ec2:RequestSpotInstances",
+      "ec2:RunInstances",
+      "ec2:StartInstances",
+      "ec2:StopInstances",
+      "ec2:CreateTags",
+      "ec2:DeleteTags",
+      "ec2:DescribeRegions",
+      "ec2:DescribeAvailabilityZones",
       "sqs:GetQueueAttributes",
       "sqs:GetQueueUrl",
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:DescribeScalingActivities",
-      "autoscaling:DescribeNotificationConfigurations",
+      "autoscaling:DescribeNotificationConfigurations"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
## what

* Add permissions to the instance profile to start/stop EC2 instances

## why

* Some applications (_e.g._ `Jenkins` with EC2 plugin) should be able to start/stop other EC2 instances (in Jenkins case, EC2 slaves) and get the permissions from the instance profile 

## references

* https://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Plugin
