### PR TITLE
Add variable for environment tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ Terraform module to provision AWS Elastic Beanstalk environment
 | ssh_listener_port |"22" |SSH port|
 | stage |"default" |Stage, e.g. 'prod', 'staging', 'dev', or 'test'|
 | tags |{} |Additional tags (e.g. `map('BusinessUnit`,`XYZ`)|
+| tier |"WebServer" |Elastic Beanstalk Environment tier, e.g. ('WebServer', 'Worker')|
 | updating_max_batch |"1" |Maximum count of instances up during update|
 | updating_min_in_service |"1" |Minimum count of instances up during update|
 | vpc_id |__REQUIRED__ |ID of the VPC in which to provision the AWS resources|
+| wait_for_ready_timeout |"20m" ||
 | zone_id |"" |Route53 parent zone ID. The module will create sub-domain DNS records in the parent zone for the EB environment|
 
 ## Output

--- a/main.tf
+++ b/main.tf
@@ -351,7 +351,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   name        = "${module.label.id}"
   application = "${var.app}"
 
-  tier                = "WebServer"
+  tier                = "${var.tier}"
   solution_stack_name = "${var.solution_stack_name}"
 
   wait_for_ready_timeout = "${var.wait_for_ready_timeout}"

--- a/variables.tf
+++ b/variables.tf
@@ -199,3 +199,8 @@ variable "env_vars" {
   type    = "map"
   description = "Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }`"
 }
+
+variable "tier" {
+  default = "WebServer"
+  description = "Elastic Beanstalk Environment tier, e.g. ('WebServer', 'Worker')"
+}


### PR DESCRIPTION
## what
* Add variable for `tier`

## why
* Currently, your module for elastic beanstalk environment doesn't have a way to set the tier for the application to be "Worker" because it is hardcoded to "WebServer".  I am asking that a variable is created for the tier with it defaulting to "WebServer" so it disrupts as little as possible. I will put in a PR shortly this Issue number.
* This is the PR for Issue #21 