### PR TITLE
Remove unnecessary current option for aws provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,9 +9,7 @@ module "label" {
   tags       = "${var.tags}"
 }
 
-data "aws_region" "default" {
-  current = true
-}
+data "aws_region" "default" {}
 
 #
 # Service


### PR DESCRIPTION
`current` option for aws provider generate the following deprecation warning:

```
$ terraform plan
Warning: module.aws-elastic-beanstalk-environment.data.aws_region.default: "current": [DEPRECATED] Defaults to current provider region if no other filtering is enabled
[...]
```

Source: https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#190-february-09-2018

Thanks for this module !