### PR TITLE
Use a variable to enable aws:ec2:vpc:AssociatePublicIpAddress

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Terraform module to provision AWS Elastic Beanstalk environment
 | healthcheck_url |"/healthcheck" |Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances|
 | http_listener_enabled |"false" |Enable port 80 (http)|
 | instance_type |"t2.micro" |Instances type|
+| associate_public_ip_address |"false" |Specifies whether to launch instances in your VPC with public IP addresses.|
 | keypair |__REQUIRED__ |Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS|
 | loadbalancer_certificate_arn |"" |Load Balancer SSL certificate ARN. The certificate must be present in AWS Certificate Manager|
 | loadbalancer_type |"classic" |Load Balancer type, e.g. 'application' or 'classic'|

--- a/main.tf
+++ b/main.tf
@@ -352,7 +352,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:ec2:vpc"
     name      = "AssociatePublicIpAddress"
-    value     = "false"
+    value     = "${var.associate_public_ip_address}"
   }
 
   setting {

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,11 @@ variable "instance_type" {
   description = "Instances type"
 }
 
+variable "associate_public_ip_address" {
+  default     = "false"
+  description = "Specifies whether to launch instances in your VPC with public IP addresses."
+}
+
 variable "autoscale_lower_bound" {
   default     = "20"
   description = "Minimum level of autoscale metric to add instance"


### PR DESCRIPTION
## what
* This pull request just adds a variable to enable the automatic creation of Elastic IP attached to instances.

## why
* If there is not NAT gateway in `private_subnets` (but an Internet gateway) there is a need to attach Elastic IP to instances in order to communicate with Elastic BeanStalk publics endpoints.
* I agree with the default value set before, `false`; a correct setup has a *NAT gateway* in a *private* subnet :)

## sources
* https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/vpc.html
* https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/vpc-no-nat.html