### PR TITLE
Set variable for rolling update policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Terraform module to provision AWS Elastic Beanstalk environment
 | stage |"default" |Stage, e.g. 'prod', 'staging', 'dev', or 'test'|
 | tags |{} |Additional tags (e.g. `map('BusinessUnit`,`XYZ`)|
 | tier |"WebServer" |Elastic Beanstalk Environment tier, e.g. ('WebServer', 'Worker')|
+| rolling_update_type |"Health" |Set it to 'Immutable' to apply the configuration change to a fresh group of instances [Read more](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.rollingupdates.html)|
 | updating_max_batch |"1" |Maximum count of instances up during update|
 | updating_min_in_service |"1" |Minimum count of instances up during update|
 | vpc_id |__REQUIRED__ |ID of the VPC in which to provision the AWS resources|

--- a/main.tf
+++ b/main.tf
@@ -374,13 +374,19 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:updatepolicy:rollingupdate"
     name      = "RollingUpdateType"
-    value     = "Health"
+    value     = "${var.rolling_update_type}"
   }
 
   setting {
     namespace = "aws:autoscaling:updatepolicy:rollingupdate"
     name      = "MinInstancesInService"
     value     = "${var.updating_min_in_service}"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:command"
+    name      = "DeploymentPolicy"
+    value     = "${var.rolling_update_type == "Immutable" ? "Immutable" : "Rolling"}"
   }
 
   setting {

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,11 @@ variable "keypair" {
   description = "Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS"
 }
 
+variable "rolling_update_type" {
+  default     = "Health"
+  description = "Set it to Immutable to apply the configuration change to a fresh group of instances"
+}
+
 variable "updating_min_in_service" {
   default     = "1"
   description = "Minimum count of instances up during update"


### PR DESCRIPTION
## what
Add a setting to use `Immutable` strategy of deployment (instead changing instances in-place, create new ones)

## why
Because immutable strategy ensure that all the process of deployment can be done from scratch (don't depend on old components, force creation of new resources for changes).

There is another `aws:elasticbeanstalk:command:DeploymentPolicy`, `AllAtOnce`, but it disables rolling deployments and always deploy to all instances simultaneously.

No sure if it is wanted to create a variable for this case (?)

## sources
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.rollingupdates.html
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environmentmgmt-updates-immutable.html
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.rolling-version-deploy.html