### PR TITLE
Add variable for EBS type and size

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Terraform module to provision AWS Elastic Beanstalk environment
 | instance_type |"t2.micro" |Instances type|
 | associate_public_ip_address |"false" |Specifies whether to launch instances in your VPC with public IP addresses.|
 | keypair |__REQUIRED__ |Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS|
+| root_volume_size |"8" |The size of the EBS root volume|
+| root_volume_type |"gp2" |The type of the EBS root volume|
 | loadbalancer_certificate_arn |"" |Load Balancer SSL certificate ARN. The certificate must be present in AWS Certificate Manager|
 | loadbalancer_type |"classic" |Load Balancer type, e.g. 'application' or 'classic'|
 | name |"app" |Solution name, e.g. 'app' or 'jenkins'|

--- a/main.tf
+++ b/main.tf
@@ -446,6 +446,16 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "${var.keypair}"
   }
   setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "RootVolumeSize"
+    value     = "${var.root_volume_size}"
+  }
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "RootVolumeType"
+    value     = "${var.root_volume_type}"
+  }
+  setting {
     namespace = "aws:autoscaling:asg"
     name      = "Availability Zones"
     value     = "Any 2"

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,16 @@ variable "keypair" {
   description = "Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS"
 }
 
+variable "root_volume_size" {
+  default     = "8"
+  description = "The size of the EBS root volume"
+}
+
+variable "root_volume_type" {
+  default     = "gp2"
+  description = "The type of the EBS root volume"
+}
+
 variable "rolling_update_type" {
   default     = "Health"
   description = "Set it to Immutable to apply the configuration change to a fresh group of instances"


### PR DESCRIPTION
## what

Set a variable for changing default EBS. Please note that because we specify the `setting`, default values come from this module, not from Elastic BeanStalk (which can be platform specific).

## why

Because `8G` might be very small is there is lot of logs generated.

## reference

https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html