### PR TITLE
Add variable for SSHSourceRestriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Terraform module to provision AWS Elastic Beanstalk environment
 | env_vars |{} |Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }`|
 | healthcheck_url |"/healthcheck" |Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances|
 | http_listener_enabled |"false" |Enable port 80 (http)|
+| ssh_source_restriction |"0.0.0.0/0" |Used to lock down SSH access to the EC2 instances. You can specify a CIDR or a security group id|
 | instance_type |"t2.micro" |Instances type|
 | associate_public_ip_address |"false" |Specifies whether to launch instances in your VPC with public IP addresses.|
 | keypair |__REQUIRED__ |Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS|

--- a/main.tf
+++ b/main.tf
@@ -432,6 +432,11 @@ resource "aws_elastic_beanstalk_environment" "default" {
   }
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SSHSourceRestriction"
+    value     = "tcp, 22, 22, ${var.ssh_source_restriction}"
+  }
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
     name      = "InstanceType"
     value     = "${var.instance_type}"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,11 @@ variable "updating_max_batch" {
   description = "Maximum count of instances up during update"
 }
 
+variable "ssh_source_restriction" {
+  default     = "0.0.0.0/0"
+  description = "Used to lock down SSH access to the EC2 instances."
+}
+
 variable "instance_type" {
   default     = "t2.micro"
   description = "Instances type"


### PR DESCRIPTION
## what

This add a variable to lock down ssh on EC2 instances

## why

Because even if a keypair is required to authenticate, bruteforce can happen on the instance (more often if an Elastic IP is attached). This can be used to authorize only a bastion host to connect. The default to let access opened is the same as AWS BeanStalk.

## reference
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html
