### PR TITLE
Add a variable for Availability Zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Terraform module to provision AWS Elastic Beanstalk environment
 | keypair |__REQUIRED__ |Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS|
 | root_volume_size |"8" |The size of the EBS root volume|
 | root_volume_type |"gp2" |The type of the EBS root volume|
+| availability_zones |"Any 2" |Choose the number of AZs for your instances|
 | loadbalancer_certificate_arn |"" |Load Balancer SSL certificate ARN. The certificate must be present in AWS Certificate Manager|
 | loadbalancer_type |"classic" |Load Balancer type, e.g. 'application' or 'classic'|
 | name |"app" |Solution name, e.g. 'app' or 'jenkins'|

--- a/main.tf
+++ b/main.tf
@@ -463,7 +463,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "Availability Zones"
-    value     = "Any 2"
+    value     = "${var.availability_zones}"
   }
   setting {
     namespace = "aws:autoscaling:asg"

--- a/variables.tf
+++ b/variables.tf
@@ -122,6 +122,11 @@ variable "root_volume_type" {
   description = "The type of the EBS root volume"
 }
 
+variable "availability_zones" {
+  default     = "Any 2"
+  description = "Choose the number of AZs for your instances"
+}
+
 variable "rolling_update_type" {
   default     = "Health"
   description = "Set it to Immutable to apply the configuration change to a fresh group of instances"


### PR DESCRIPTION
## what

Change the default Availability Zones from `Any 2` to  `Any`.

## why

If there is more than 2 AZs in a region, use all AZs:

`Availability Zones (AZs) are distinct locations within a region that are engineered to be isolated from failures in other AZs and provide inexpensive, low-latency network connectivity to other AZs in the same region. Choose the number of AZs for your instances.`

For example region **eu-west-1** and **eu-west-3** has 3 differents AZs.
~~I think there is no need to provide a variable for this; it works on all cases (1 instance, 3 instances, 6 instances, etc...).~~

## reference

* https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html
* https://github.com/jsonmaur/aws-regions (unofficial list of all AZs per regions)