### PR TITLE
Add custom metrics for CloudWatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Terraform module to provision AWS Elastic Beanstalk environment
 | env_default_key |"DEFAULT_ENV_%d" |Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting|
 | env_default_value |"UNSET" |Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting|
 | env_vars |{} |Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }`|
+| config_document |{ \"CloudWatchMetrics\": {}, \"Version\": 1} (none) |A JSON document describing the environment and instance metrics to publish to CloudWatch [Read more](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-cloudwatch.html#health-enhanced-cloudwatch-configdocument)|
 | healthcheck_url |"/healthcheck" |Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances|
 | http_listener_enabled |"false" |Enable port 80 (http)|
 | ssh_source_restriction |"0.0.0.0/0" |Used to lock down SSH access to the EC2 instances. You can specify a CIDR or a security group id|

--- a/main.tf
+++ b/main.tf
@@ -571,6 +571,11 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "${var.loadbalancer_certificate_arn}"
   }
   setting {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name      = "ConfigDocument"
+    value     = "${var.config_document}"
+  }
+  setting {
     namespace = "aws:elasticbeanstalk:application"
     name      = "Application Healthcheck URL"
     value     = "HTTP:80${var.healthcheck_url}"

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,11 @@ variable "name" {
   description = "Solution name, e.g. 'app' or 'jenkins'"
 }
 
+variable "config_document" {
+  default     = "{ \"CloudWatchMetrics\": {}, \"Version\": 1}"
+  description = "A JSON document describing the environment and instance metrics to publish to CloudWatch."
+}
+
 variable "healthcheck_url" {
   default     = "/healthcheck"
   description = "Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances"


### PR DESCRIPTION
:warning: ~~Please don't merge directly, this break the creation of the environment if default not defined!~~ :warning:

## what

Enable some interesting CloudWatch metrics. I think this is considered as custom metrics (so charges can apply) because they are not created by default.

## why

Without that, it is difficult to get metrics from the ELB or instances *directly*.
Some metrics about instances such as `RootFilesystemUtil` are custom metrics but not managed by user!

## problem

~~the option need to be defined with a value, or not defined (so empty default produce an error)~~:

```
Failed Environment update activity. Reason: Configuration validation exception: Invalid option specification (Namespace: 'aws:elasticbeanstalk:healthreporting:system', OptionName: 'ConfigDocument'): Unknown configuration setting.
```

~~I don't see how to provide a way in `terraform` to define a value and let the default not defined, as it is a setting inside a single `resource` (i'm aware of interpolation conditionals but it not help here).
A solution can be to enable one metric,~~
EDIT: problem solved by creating a default JSON document.

## references

* https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html
* https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aeb-metricscollected.html