### PR TITLE
Add variables for managed updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Terraform module to provision AWS Elastic Beanstalk environment
 | autoscale_min |"2" |Minumum instances in charge|
 | autoscale_upper_bound |"80" |Maximum level of autoscale metric to remove instance|
 | config_source |"" |S3 source for config|
+| preferred_start_time |"Sun:10:00" |Configure a maintenance window for managed actions in UTC|
+| update_level |"minor" |The highest level of update to apply with managed platform updates. patch for patch version updates only. minor for both minor and patch version updates|
+| instance_refresh_enabled |"true" |Enable weekly instance replacement.|
 | delimiter |"-" |Delimiter to be used between `name`, `namespace`, `stage`, etc.|
 | env_default_key |"DEFAULT_ENV_%d" |Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting|
 | env_default_value |"UNSET" |Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting|

--- a/main.tf
+++ b/main.tf
@@ -623,17 +623,17 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:elasticbeanstalk:managedactions"
     name      = "PreferredStartTime"
-    value     = "Sun:10:00"
+    value     = "${var.preferred_start_time}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:managedactions:platformupdate"
     name      = "UpdateLevel"
-    value     = "minor"
+    value     = "${var.update_level}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:managedactions:platformupdate"
     name      = "InstanceRefreshEnabled"
-    value     = "true"
+    value     = "${var.instance_refresh_enabled}"
   }
   ###===================== Application ENV vars ======================###
   setting {

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,21 @@ variable "config_source" {
   description = "S3 source for config"
 }
 
+variable "preferred_start_time" {
+  default     = "Sun:10:00"
+  description = "Configure a maintenance window for managed actions in UTC"
+}
+
+variable "update_level" {
+  default     = "minor"
+  description = "The highest level of update to apply with managed platform updates"
+}
+
+variable "instance_refresh_enabled" {
+  default     = "true"
+  description = "Enable weekly instance replacement."
+}
+
 variable "security_groups" {
   type        = "list"
   description = "List of security groups to be allowed to connect to the EC2 instances"


### PR DESCRIPTION
## what

Add variables for maintenance window, update level and instance refresh.

## why

For production, a desired value for update_level can be `patch` while the default `minor` can be for staging envs.
There is no need to set a variable for `ManagedActionsEnabled` because if set to false will produce configuration error because , `PreferredStartTime` and `UpdateLevel` are set.

## references

* https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elasticbeanstalkmanagedactionsplatformupdate
* https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elasticbeanstalkmanagedactions