### PR TITLE
Idempotent Configurations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -326,20 +326,25 @@ resource "aws_security_group" "default" {
   tags = "${module.label.tags}"
 }
 
+resource "aws_elastic_beanstalk_environment" "default" {
+  name                   = "${module.label.id}"
+  application            = "${var.app}"
+  tier                   = "${var.tier}"
+  template_name          = "${aws_elastic_beanstalk_configuration_template.default.id}"
+  depends_on             = ["aws_elastic_beanstalk_configuration_template.default"]
+  wait_for_ready_timeout = "${var.wait_for_ready_timeout}"
+  tags                   = "${module.label.tags}"
+}
+
 #
 # Full list of options:
 # http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elasticbeanstalkmanagedactionsplatformupdate
 #
-resource "aws_elastic_beanstalk_environment" "default" {
+resource "aws_elastic_beanstalk_configuration_template" "default" {
   name        = "${module.label.id}"
   application = "${var.app}"
 
-  tier                = "${var.tier}"
   solution_stack_name = "${var.solution_stack_name}"
-
-  wait_for_ready_timeout = "${var.wait_for_ready_timeout}"
-
-  tags = "${module.label.tags}"
 
   setting {
     namespace = "aws:ec2:vpc"


### PR DESCRIPTION
:warning: this is PR **don't work** as expected, just used to show code :warning: 

## what

Use a configuration template to configure the environment.

## why

Without this PR, each `terraform plan` present a `change`, even if no modification are made (maybe because the resource create a new `setting` id ?):

```
module.aws-elastic-beanstalk-environment.aws_elastic_beanstalk_environment.default: Modifying... (ID: e-eb5rg9f3ef)
  setting.#:                    "101" => "113"
[...]
```

When using this PR:

```
- module.aws-elastic-beanstalk-environment
  Getting source "git@github.com:guikcd/terraform-aws-elastic-beanstalk-environment.git?ref=beanstalk_template"
- module.aws-elastic-beanstalk-environment.label
  Getting source "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.1"
- module.aws-elastic-beanstalk-environment.tld
  Getting source "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.1.1"
[...]
aws_elastic_beanstalk_configuration_template.default: Refreshing state... (ID: xxxxxx)
aws_elastic_beanstalk_environment.default: Refreshing state... (ID: e-xxxxxx)
aws_route53_record.default: Refreshing state... (ID: Z341ZI21D61SE0_xxxxxx_CNAME)

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

A non idem potem behavior is complicated when reviewing modifications (particularly on production environments).

## problem

Idem potem is guaranteed, *but* the modification of the template **does not** trigger any modification of the environment. I didn't manage to find a way to trigger this in terraform.

Instead of adding this feature, i maybe need to open a issue/pr on terraform provider aws (https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_elastic_beanstalk_environment.go#L314) to see why the computed `setting` list changes even if no modification are made in *.tf files ?

Discussion opened :)

## references

https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-configuration-savedconfig.html