### PR TITLE
Bump `terraform-null-label` version. Make `zone_id` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Available targets:
 | alb_zone_id | ALB zone id | string | `<map>` | no |
 | app | EBS application name | string | - | yes |
 | associate_public_ip_address | Specifies whether to launch instances in your VPC with public IP addresses. | string | `false` | no |
-| attributes | Additional attributes (e.g. `policy` or `role`) | list | `<list>` | no |
+| attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | autoscale_lower_bound | Minimum level of autoscale metric to add instance | string | `20` | no |
 | autoscale_max | Maximum instances in charge | string | `3` | no |
 | autoscale_min | Minumum instances in charge | string | `2` | no |
@@ -73,7 +73,7 @@ Available targets:
 | loadbalancer_certificate_arn | Load Balancer SSL certificate ARN. The certificate must be present in AWS Certificate Manager | string | `` | no |
 | loadbalancer_type | Load Balancer type, e.g. 'application' or 'classic' | string | `classic` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `app` | no |
-| namespace | Namespace, which could be your organization name, e.g. 'cp' or 'cloudposse' | string | `global` | no |
+| namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
 | notification_endpoint | Notification endpoint | string | `` | no |
 | notification_protocol | Notification protocol | string | `email` | no |
 | notification_topic_arn | Notification topic arn | string | `` | no |
@@ -89,13 +89,13 @@ Available targets:
 | ssh_listener_enabled | Enable ssh port | string | `false` | no |
 | ssh_listener_port | SSH port | string | `22` | no |
 | ssh_source_restriction | Used to lock down SSH access to the EC2 instances. | string | `0.0.0.0/0` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `default` | no |
+| stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | - | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | tier | Elastic Beanstalk Environment tier, e.g. ('WebServer', 'Worker') | string | `WebServer` | no |
 | update_level | The highest level of update to apply with managed platform updates | string | `minor` | no |
 | updating_max_batch | Maximum count of instances up during update | string | `1` | no |
 | updating_min_in_service | Minimum count of instances up during update | string | `1` | no |
-| version_label | Elastic Beanstalk Application version for deploy | string | `` | no |
+| version_label | Elastic Beanstalk Application version to deploy | string | `` | no |
 | vpc_id | ID of the VPC in which to provision the AWS resources | string | - | yes |
 | wait_for_ready_timeout |  | string | `20m` | no |
 | zone_id | Route53 parent zone ID. The module will create sub-domain DNS records in the parent zone for the EB environment | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,7 +6,7 @@
 | alb_zone_id | ALB zone id | string | `<map>` | no |
 | app | EBS application name | string | - | yes |
 | associate_public_ip_address | Specifies whether to launch instances in your VPC with public IP addresses. | string | `false` | no |
-| attributes | Additional attributes (e.g. `policy` or `role`) | list | `<list>` | no |
+| attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | autoscale_lower_bound | Minimum level of autoscale metric to add instance | string | `20` | no |
 | autoscale_max | Maximum instances in charge | string | `3` | no |
 | autoscale_min | Minumum instances in charge | string | `2` | no |
@@ -26,7 +26,7 @@
 | loadbalancer_certificate_arn | Load Balancer SSL certificate ARN. The certificate must be present in AWS Certificate Manager | string | `` | no |
 | loadbalancer_type | Load Balancer type, e.g. 'application' or 'classic' | string | `classic` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `app` | no |
-| namespace | Namespace, which could be your organization name, e.g. 'cp' or 'cloudposse' | string | `global` | no |
+| namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
 | notification_endpoint | Notification endpoint | string | `` | no |
 | notification_protocol | Notification protocol | string | `email` | no |
 | notification_topic_arn | Notification topic arn | string | `` | no |
@@ -42,13 +42,13 @@
 | ssh_listener_enabled | Enable ssh port | string | `false` | no |
 | ssh_listener_port | SSH port | string | `22` | no |
 | ssh_source_restriction | Used to lock down SSH access to the EC2 instances. | string | `0.0.0.0/0` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | `default` | no |
+| stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | string | - | yes |
 | tags | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | tier | Elastic Beanstalk Environment tier, e.g. ('WebServer', 'Worker') | string | `WebServer` | no |
 | update_level | The highest level of update to apply with managed platform updates | string | `minor` | no |
 | updating_max_batch | Maximum count of instances up during update | string | `1` | no |
 | updating_min_in_service | Minimum count of instances up during update | string | `1` | no |
-| version_label | Elastic Beanstalk Application version for deploy | string | `` | no |
+| version_label | Elastic Beanstalk Application version to deploy | string | `` | no |
 | vpc_id | ID of the VPC in which to provision the AWS resources | string | - | yes |
 | wait_for_ready_timeout |  | string | `20m` | no |
 | zone_id | Route53 parent zone ID. The module will create sub-domain DNS records in the parent zone for the EB environment | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Define composite variables for resources
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.3"
   namespace  = "${var.namespace}"
   name       = "${var.name}"
   stage      = "${var.stage}"
@@ -970,10 +970,11 @@ resource "aws_s3_bucket" "elb_logs" {
 }
 
 module "tld" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.1.1"
+  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.5"
   namespace = "${var.namespace}"
   name      = "${var.name}"
   stage     = "${var.stage}"
   zone_id   = "${var.zone_id}"
   records   = ["${aws_elastic_beanstalk_environment.default.cname}"]
+  enabled   = "${length(var.zone_id) > 0 ? "true" : "false"}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
 variable "namespace" {
-  default     = "global"
-  description = "Namespace, which could be your organization name, e.g. 'cp' or 'cloudposse'"
+  type        = "string"
+  description = "Namespace, which could be your organization name, e.g. 'eg' or 'cp'"
 }
 
 variable "stage" {
-  default     = "default"
+  type        = "string"
   description = "Stage, e.g. 'prod', 'staging', 'dev', or 'test'"
 }
 
@@ -17,7 +17,7 @@ variable "delimiter" {
 variable "attributes" {
   type        = "list"
   default     = []
-  description = "Additional attributes (e.g. `policy` or `role`)"
+  description = "Additional attributes (e.g. `1`)"
 }
 
 variable "name" {
@@ -258,5 +258,5 @@ variable "tier" {
 
 variable "version_label" {
   default     = ""
-  description = "Elastic Beanstalk Application version for deploy"
+  description = "Elastic Beanstalk Application version to deploy"
 }


### PR DESCRIPTION
## what
* Bump `terraform-null-label` version
* Make `zone_id` optional

## why
* New `terraform-null-label` version fixes the issue with empty tag values (which breaks Elastic Beanstalk environment)
* Don't create a DNS record if `zone_id` is empty. Not all applications require a friendly DNS name for EB environment
