### PR TITLE
Add Load balancer security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Available targets:
 | instance_type | Instances type | string | `t2.micro` | no |
 | keypair | Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS | string | - | yes |
 | loadbalancer_certificate_arn | Load Balancer SSL certificate ARN. The certificate must be present in AWS Certificate Manager | string | `` | no |
+| loadbalancer_managed_security_group | Load balancer managed security group | string | `` | no |
+| loadbalancer_security_groups | Load balancer security groups | list | `<list>` | no |
 | loadbalancer_type | Load Balancer type, e.g. 'application' or 'classic' | string | `classic` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `app` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,6 +24,8 @@
 | instance_type | Instances type | string | `t2.micro` | no |
 | keypair | Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS | string | - | yes |
 | loadbalancer_certificate_arn | Load Balancer SSL certificate ARN. The certificate must be present in AWS Certificate Manager | string | `` | no |
+| loadbalancer_managed_security_group | Load balancer managed security group | string | `` | no |
+| loadbalancer_security_groups | Load balancer security groups | list | `<list>` | no |
 | loadbalancer_type | Load Balancer type, e.g. 'application' or 'classic' | string | `classic` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `app` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -484,6 +484,16 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "true"
   }
   setting {
+    namespace = "aws:elb:loadbalancer"
+    name      = "SecurityGroups"
+    value     = "${join(",", var.loadbalancer_security_groups)}"
+  }
+  setting {
+    namespace = "aws:elb:loadbalancer"
+    name      = "ManagedSecurityGroup"
+    value     = "${var.loadbalancer_managed_security_group}"
+  }
+  setting {
     namespace = "aws:elb:listener"
     name      = "ListenerProtocol"
     value     = "HTTP"
@@ -552,6 +562,16 @@ resource "aws_elastic_beanstalk_environment" "default" {
     namespace = "aws:elbv2:loadbalancer"
     name      = "AccessLogsS3Enabled"
     value     = "true"
+  }
+  setting {
+    namespace = "aws:elbv2:loadbalancer"
+    name      = "SecurityGroups"
+    value     = "${join(",", var.loadbalancer_security_groups)}"
+  }
+  setting {
+    namespace = "aws:elbv2:loadbalancer"
+    name      = "ManagedSecurityGroup"
+    value     = "${var.loadbalancer_managed_security_group}"
   }
   setting {
     namespace = "aws:elbv2:listener:default"

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,18 @@ variable "loadbalancer_certificate_arn" {
   description = "Load Balancer SSL certificate ARN. The certificate must be present in AWS Certificate Manager"
 }
 
+variable "loadbalancer_security_groups" {
+  type        = "list"
+  default     = []
+  description = "Load balancer security groups"
+}
+
+variable "loadbalancer_managed_security_group" {
+  type        = "string"
+  default     = ""
+  description = "Load balancer managed security group"
+}
+
 variable "http_listener_enabled" {
   default     = "false"
   description = "Enable port 80 (http)"


### PR DESCRIPTION
## what

Add the possibility to use existing security groups when creating load balancer, and stop the creation of the default security group.

## why

The default behaviour when creating a load balancer is to create a security group which allow `0.0.0.0` to access to it. I need to allow only a specific cidr.

There are two variables :

* loadbalancer_security_groups : list of security groups to attach
* loadbalancer_managed_security_group : A single SG. If you don't fill this variable, it will continue to create a default security group.

Example : Use a custom SG which allow only my network :

```
  loadbalancer_security_groups = ["${module.sg.this_security_group_id}"]
  loadbalancer_managed_security_group = "${module.sg.this_security_group_id}"
  ```

If you don't fill theses two variables, you have the classical workflow.


## references

-  https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elasticbeanstalkmanagedactionsplatformupdate