### PR TITLE
Add force_destroy option for S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Available targets:
 | vpc_id | ID of the VPC in which to provision the AWS resources | string | - | yes |
 | wait_for_ready_timeout |  | string | `20m` | no |
 | zone_id | Route53 parent zone ID. The module will create sub-domain DNS records in the parent zone for the EB environment | string | `` | no |
+| force_destroy | Destroy S3 bucket for load balancer logs | boolean | false | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Available targets:
 | vpc_id | ID of the VPC in which to provision the AWS resources | string | - | yes |
 | wait_for_ready_timeout |  | string | `20m` | no |
 | zone_id | Route53 parent zone ID. The module will create sub-domain DNS records in the parent zone for the EB environment | string | `` | no |
-| force_destroy | Destroy S3 bucket for load balancer logs | boolean | false | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Available targets:
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
+| force_destroy | Destroy S3 bucket for load balancer logs | string | `false` | no |
 | healthcheck_url | Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances | string | `/healthcheck` | no |
 | http_listener_enabled | Enable port 80 (http) | string | `false` | no |
 | instance_refresh_enabled | Enable weekly instance replacement. | string | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,6 +18,7 @@
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
+| force_destroy | Destroy S3 bucket for load balancer logs | string | `false` | no |
 | healthcheck_url | Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances | string | `/healthcheck` | no |
 | http_listener_enabled | Enable port 80 (http) | string | `false` | no |
 | instance_refresh_enabled | Enable weekly instance replacement. | string | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -991,7 +991,7 @@ resource "aws_s3_bucket" "elb_logs" {
   bucket        = "${module.label.id}-logs"
   acl           = "private"
   force_destroy = "${force_destroy}"
-  policy = "${data.aws_iam_policy_document.elb_logs.json}"
+  policy        = "${data.aws_iam_policy_document.elb_logs.json}"
 }
 
 module "tld" {

--- a/main.tf
+++ b/main.tf
@@ -990,7 +990,7 @@ data "aws_iam_policy_document" "elb_logs" {
 resource "aws_s3_bucket" "elb_logs" {
   bucket        = "${module.label.id}-logs"
   acl           = "private"
-  force_destroy = "${force_destroy}"
+  force_destroy = "${var.force_destroy}"
   policy        = "${data.aws_iam_policy_document.elb_logs.json}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -988,9 +988,9 @@ data "aws_iam_policy_document" "elb_logs" {
 }
 
 resource "aws_s3_bucket" "elb_logs" {
-  bucket = "${module.label.id}-logs"
-  acl    = "private"
-
+  bucket        = "${module.label.id}-logs"
+  acl           = "private"
+  force_destroy = "${force_destroy}"
   policy = "${data.aws_iam_policy_document.elb_logs.json}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -277,3 +277,8 @@ variable "nodejs_version" {
   default     = ""
   description = "Elastic Beanstalk NodeJS version to deploy"
 }
+
+variable "force_destroy" {
+  default     = false
+  description = "Destroy S3 bucket for load balancer logs"
+}


### PR DESCRIPTION
## what
Add `orce_destroy` option for S3 bucket

## why
After running destroy the S3 bucket for load balancer logs is not destroyed

