### PR TITLE
Support parameterization for variables that aren't supported in Windows-based EB platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Available targets:
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
+| health_reporting_system | Which health system, `enhanched` (default) or `basic` to deploy to the environment | string | `enhanched` | no |
 | healthcheck_url | Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances | string | `/healthcheck` | no |
 | http_listener_enabled | Enable port 80 (http) | string | `false` | no |
 | instance_refresh_enabled | Enable weekly instance replacement. | string | `true` | no |
@@ -75,6 +76,7 @@ Available targets:
 | loadbalancer_managed_security_group | Load balancer managed security group | string | `` | no |
 | loadbalancer_security_groups | Load balancer security groups | list | `<list>` | no |
 | loadbalancer_type | Load Balancer type, e.g. 'application' or 'classic' | string | `classic` | no |
+| managed_actions_enabled | whether managed actions are turned on for this environment | string | `true` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `app` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
 | nodejs_version | Elastic Beanstalk NodeJS version to deploy | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,6 +18,7 @@
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
+| health_reporting_system | Which health system, `enhanched` (default) or `basic` to deploy to the environment | string | `enhanched` | no |
 | healthcheck_url | Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances | string | `/healthcheck` | no |
 | http_listener_enabled | Enable port 80 (http) | string | `false` | no |
 | instance_refresh_enabled | Enable weekly instance replacement. | string | `true` | no |
@@ -27,6 +28,7 @@
 | loadbalancer_managed_security_group | Load balancer managed security group | string | `` | no |
 | loadbalancer_security_groups | Load balancer security groups | list | `<list>` | no |
 | loadbalancer_type | Load Balancer type, e.g. 'application' or 'classic' | string | `classic` | no |
+| managed_actions_enabled | whether managed actions are turned on for this environment | string | `true` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `app` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
 | nodejs_version | Elastic Beanstalk NodeJS version to deploy | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -601,7 +601,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:elasticbeanstalk:application"
     name      = "Application Healthcheck URL"
-    value     = "HTTP:80${var.healthcheck_url}"
+    value     = "${var.healthcheck_url}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:environment"

--- a/main.tf
+++ b/main.tf
@@ -646,7 +646,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:elasticbeanstalk:managedactions"
     name      = "ManagedActionsEnabled"
-    value     = "true"
+    value     = "${var.managed_actions_enabled}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:managedactions"

--- a/main.tf
+++ b/main.tf
@@ -616,7 +616,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:elasticbeanstalk:healthreporting:system"
     name      = "SystemType"
-    value     = "enhanced"
+    value     = "${var.health_reporting_system}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:command"

--- a/variables.tf
+++ b/variables.tf
@@ -279,11 +279,11 @@ variable "nodejs_version" {
 }
 
 variable "health_reporting_system" {
-  default = "enhanched" 
+  default     = "enhanched"
   description = "Which health system, `enhanched` (default) or `basic` to deploy to the environment"
 }
 
 variable "managed_actions_enabled" {
-  default = "true"
+  default     = "true"
   description = "whether managed actions are turned on for this environment"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -282,3 +282,8 @@ variable "health_reporting_system" {
   default = "enhanched" 
   description = "Which health system, `enhanched` (default) or `basic` to deploy to the environment"
 }
+
+variable "managed_actions_enables" {
+  default = "true"
+  description = "whether managed actions are turned on for this environment"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -277,3 +277,8 @@ variable "nodejs_version" {
   default     = ""
   description = "Elastic Beanstalk NodeJS version to deploy"
 }
+
+variable "health_reporting_system" {
+  default = "enhanched" 
+  description = "Which health system, `enhanched` (default) or `basic` to deploy to the environment"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -283,7 +283,7 @@ variable "health_reporting_system" {
   description = "Which health system, `enhanched` (default) or `basic` to deploy to the environment"
 }
 
-variable "managed_actions_enables" {
+variable "managed_actions_enabled" {
   default = "true"
   description = "whether managed actions are turned on for this environment"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -285,5 +285,5 @@ variable "health_reporting_system" {
 
 variable "managed_actions_enabled" {
   default     = "true"
-  description = "whether managed actions are turned on for this environment"
+  description = "Flag used to control whether or not managed actions are turned on for this environment"
 }


### PR DESCRIPTION
## what
*  Moved hardcoded settings into variables with sane default values

## why
* Health Reporting System doesn't support `enhanched` under Windows
* Managed Actions is not supported under Windows
* Application Healthcheck URL may use protocol other that HTTP:80
