### PR TITLE
Use terraform-terraform-label 0.1.6 for module.label

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Define composite variables for resources
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.3"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
   namespace  = "${var.namespace}"
   name       = "${var.name}"
   stage      = "${var.stage}"


### PR DESCRIPTION
## Problem

The `terraform-null-label` grew a bit complex and is throwing errors when used:

```
* module.sc-api-env-active.module.elastic_beanstalk_environment.module.label.data.null_data_source.tags_as_list_of_maps: data.null_data_source.tags_as_list_of_maps: value of 'count' cannot be computed
```

## Solution

Changed the label to use `terraform-terraform-label` instead.

## Testing

tf plan `example/complete` and verify it finishes successfully.