### PR TITLE
DEVOPS-232: Add aws:elasticbeanstalk:cloudwatch:logs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ Available targets:
 | config_source | S3 source for config | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | description | Short description of the Environment | string | `` | no |
+| enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application. | string | `false` | no |
 | enable_managed_actions | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | string | `true` | no |
+| enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment. | string | `false` | no |
+| enable_xray | AWS X-Ray is an AWS service that gathers data about the requests that your application serves, and uses it to construct a service map that you can use to identify issues with your application and opportunities for optimization. Some regions don't offer AWS X-Ray. If you create an environment in one of these regions, you can't run the AWS X-Ray daemon on the instances in your environment. | string | `false` | no |
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
@@ -86,6 +89,8 @@ Available targets:
 | loadbalancer_managed_security_group | Load balancer managed security group | string | `` | no |
 | loadbalancer_security_groups | Load balancer security groups | list | `<list>` | no |
 | loadbalancer_type | Load Balancer type, e.g. 'application' or 'classic' | string | `classic` | no |
+| logs_delete_on_terminate | Whether to delete the log groups when the environment is terminated. If false, the logs are kept RetentionInDays days. | string | `false` | no |
+| logs_retention_in_days | The number of days to keep log events before they expire. | string | `7` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `app` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
 | nodejs_version | Elastic Beanstalk NodeJS version to deploy | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Available targets:
 | enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application. | string | `false` | no |
 | enable_managed_actions | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | string | `true` | no |
 | enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment. | string | `false` | no |
-| enable_xray | AWS X-Ray is an AWS service that gathers data about the requests that your application serves, and uses it to construct a service map that you can use to identify issues with your application and opportunities for optimization. Some regions don't offer AWS X-Ray. If you create an environment in one of these regions, you can't run the AWS X-Ray daemon on the instances in your environment. | string | `false` | no |
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,7 +21,10 @@
 | config_source | S3 source for config | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | description | Short description of the Environment | string | `` | no |
+| enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application. | string | `false` | no |
 | enable_managed_actions | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | string | `true` | no |
+| enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment. | string | `false` | no |
+| enable_xray | AWS X-Ray is an AWS service that gathers data about the requests that your application serves, and uses it to construct a service map that you can use to identify issues with your application and opportunities for optimization. Some regions don't offer AWS X-Ray. If you create an environment in one of these regions, you can't run the AWS X-Ray daemon on the instances in your environment. | string | `false` | no |
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
@@ -38,6 +41,8 @@
 | loadbalancer_managed_security_group | Load balancer managed security group | string | `` | no |
 | loadbalancer_security_groups | Load balancer security groups | list | `<list>` | no |
 | loadbalancer_type | Load Balancer type, e.g. 'application' or 'classic' | string | `classic` | no |
+| logs_delete_on_terminate | Whether to delete the log groups when the environment is terminated. If false, the logs are kept RetentionInDays days. | string | `false` | no |
+| logs_retention_in_days | The number of days to keep log events before they expire. | string | `7` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | string | `app` | no |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | string | - | yes |
 | nodejs_version | Elastic Beanstalk NodeJS version to deploy | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,7 +24,6 @@
 | enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application. | string | `false` | no |
 | enable_managed_actions | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | string | `true` | no |
 | enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment. | string | `false` | no |
-| enable_xray | AWS X-Ray is an AWS service that gathers data about the requests that your application serves, and uses it to construct a service map that you can use to identify issues with your application and opportunities for optimization. Some regions don't offer AWS X-Ray. If you create an environment in one of these regions, you can't run the AWS X-Ray daemon on the instances in your environment. | string | `false` | no |
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |

--- a/main.tf
+++ b/main.tf
@@ -403,36 +403,32 @@ resource "aws_elastic_beanstalk_environment" "default" {
 
   setting {
     namespace = "aws:elasticbeanstalk:xray"
-    name = "XRayEnabled"
-    value = "${var.enable_xray ? "true" : "false"}"
+    name      = "XRayEnabled"
+    value     = "${var.enable_xray ? "true" : "false"}"
   }
 
   ###=========================== Logging ========================== ###
 
   setting {
     namespace = "aws:elasticbeanstalk:hostmanager"
-    name = "LogPublicationControl"
-    value = "${var.enable_log_publication_control ? "true" : "false"}"
+    name      = "LogPublicationControl"
+    value     = "${var.enable_log_publication_control ? "true" : "false"}"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:cloudwatch:logs"
-    name = "StreamLogs"
-    value = "${var.enable_stream_logs ? "true" : "false"}"
+    name      = "StreamLogs"
+    value     = "${var.enable_stream_logs ? "true" : "false"}"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:cloudwatch:logs"
-    name = "DeleteOnTerminate"
-    value = "${var.logs_delete_on_terminate ? "true" : "false"}"
+    name      = "DeleteOnTerminate"
+    value     = "${var.logs_delete_on_terminate ? "true" : "false"}"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:cloudwatch:logs"
-    name = "RetentionInDays"
-    value = "${var.logs_retention_in_days}"
+    name      = "RetentionInDays"
+    value     = "${var.logs_retention_in_days}"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
     name      = "HealthStreamingEnabled"

--- a/main.tf
+++ b/main.tf
@@ -399,6 +399,14 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "${var.updating_max_batch}"
   }
 
+  ###=========================== Debugging ========================== ###
+
+  setting {
+    namespace = "aws:elasticbeanstalk:xray"
+    name = "XRayEnabled"
+    value = "${var.enable_xray ? "true" : "false"}"
+  }
+
   ###=========================== Logging ========================== ###
 
   setting {

--- a/main.tf
+++ b/main.tf
@@ -399,6 +399,48 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "${var.updating_max_batch}"
   }
 
+  ###=========================== Logging ========================== ###
+
+  setting {
+    namespace = "aws:elasticbeanstalk:hostmanager"
+    name = "LogPublicationControl"
+    value = "${var.enable_log_publication_control ? "true" : "false"}"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name = "StreamLogs"
+    value = "${var.enable_stream_logs ? "true" : "false"}"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name = "DeleteOnTerminate"
+    value = "${var.logs_delete_on_terminate ? "true" : "false"}"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name = "RetentionInDays"
+    value = "${var.logs_retention_in_days}"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
+    name      = "HealthStreamingEnabled"
+    value     = "${var.health_streaming_enabled ? "true" : "false"}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
+    name      = "DeleteOnTerminate"
+    value     = "${var.health_streaming_delete_on_terminate ? "true" : "false"}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
+    name      = "RetentionInDays"
+    value     = "${var.health_streaming_retention_in_days}"
+  }
+
   ###=========================== Autoscale trigger ========================== ###
 
   setting {
@@ -603,21 +645,6 @@ resource "aws_elastic_beanstalk_environment" "default" {
     namespace = "aws:elbv2:listener:443"
     name      = "SSLCertificateArns"
     value     = "${var.loadbalancer_certificate_arn}"
-  }
-  setting {
-    namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
-    name      = "HealthStreamingEnabled"
-    value     = "${var.health_streaming_enabled ? "true" : "false"}"
-  }
-  setting {
-    namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
-    name      = "DeleteOnTerminate"
-    value     = "${var.health_streaming_delete_on_terminate ? "true" : "false"}"
-  }
-  setting {
-    namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
-    name      = "RetentionInDays"
-    value     = "${var.health_streaming_retention_in_days}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:healthreporting:system"

--- a/main.tf
+++ b/main.tf
@@ -399,14 +399,6 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "${var.updating_max_batch}"
   }
 
-  ###=========================== Debugging ========================== ###
-
-  setting {
-    namespace = "aws:elasticbeanstalk:xray"
-    name      = "XRayEnabled"
-    value     = "${var.enable_xray ? "true" : "false"}"
-  }
-
   ###=========================== Logging ========================== ###
 
   setting {

--- a/variables.tf
+++ b/variables.tf
@@ -76,10 +76,9 @@ variable "notification_topic_name" {
 }
 
 variable "enable_xray" {
-  default = false
-  description = ""
+  default     = false
+  description = "AWS X-Ray is an AWS service that gathers data about the requests that your application serves, and uses it to construct a service map that you can use to identify issues with your application and opportunities for optimization. Some regions don't offer AWS X-Ray. If you create an environment in one of these regions, you can't run the AWS X-Ray daemon on the instances in your environment."
 }
-
 
 variable "enable_log_publication_control" {
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -75,11 +75,6 @@ variable "notification_topic_name" {
   description = "Notification topic name"
 }
 
-variable "enable_xray" {
-  default     = false
-  description = "AWS X-Ray is an AWS service that gathers data about the requests that your application serves, and uses it to construct a service map that you can use to identify issues with your application and opportunities for optimization. Some regions don't offer AWS X-Ray. If you create an environment in one of these regions, you can't run the AWS X-Ray daemon on the instances in your environment."
-}
-
 variable "enable_log_publication_control" {
   default     = false
   description = "Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application."

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,12 @@ variable "notification_topic_name" {
   description = "Notification topic name"
 }
 
+variable "enable_xray" {
+  default = false
+  description = ""
+}
+
+
 variable "enable_log_publication_control" {
   default     = false
   description = "Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application."

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,26 @@ variable "notification_topic_name" {
   description = "Notification topic name"
 }
 
+variable "enable_log_publication_control" {
+  default     = false
+  description = "Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application."
+}
+
+variable "enable_stream_logs" {
+  default     = false
+  description = "Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment."
+}
+
+variable "logs_delete_on_terminate" {
+  default     = false
+  description = "Whether to delete the log groups when the environment is terminated. If false, the logs are kept RetentionInDays days."
+}
+
+variable "logs_retention_in_days" {
+  default     = "7"
+  description = "The number of days to keep log events before they expire."
+}
+
 variable "loadbalancer_type" {
   default     = "classic"
   description = "Load Balancer type, e.g. 'application' or 'classic'"


### PR DESCRIPTION
## Feature

Support log settings.

## Solution

- Added support for `aws:elasticbeanstalk:hostmanager`, `aws:elasticbeanstalk:cloudwatch:logs`, and `aws:elasticbeanstalk:cloudwatch:logs:health` options

https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-logging.html

## Testing

- Tested locally with a parent module worked as expected

<img width="1412" alt="screen shot 2018-10-31 at 5 26 53 pm" src="https://user-images.githubusercontent.com/134952/47822437-30b3e780-dd32-11e8-8f1e-3323dc784be0.png">
