### PR TITLE
Add option to specify environment type

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Available targets:
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
-| environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time' and `updating_min_in_service` must be set to 0 | string | `LoadBalanced` | no |
+| environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time', `updating_min_in_service` must be set to 0, and `public_subnets` will be unused (it applies to the ELB, which does not exist in SingleInstance environments) | string | `LoadBalanced` | no |
 | force_destroy | Destroy S3 bucket for load balancer logs | string | `false` | no |
 | health_streaming_delete_on_terminate | Whether to delete the log group when the environment is terminated. If false, the health data is kept RetentionInDays days. | string | `false` | no |
 | health_streaming_enabled | For environments with enhanced health reporting enabled, whether to create a group in CloudWatch Logs for environment health and archive Elastic Beanstalk environment health data. For information about enabling enhanced health, see aws:elasticbeanstalk:healthreporting:system. | string | `false` | no |

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Available targets:
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
+| environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance' | string | `LoadBalanced` | no |
 | force_destroy | Destroy S3 bucket for load balancer logs | string | `false` | no |
 | health_streaming_delete_on_terminate | Whether to delete the log group when the environment is terminated. If false, the health data is kept RetentionInDays days. | string | `false` | no |
 | health_streaming_enabled | For environments with enhanced health reporting enabled, whether to create a group in CloudWatch Logs for environment health and archive Elastic Beanstalk environment health data. For information about enabling enhanced health, see aws:elasticbeanstalk:healthreporting:system. | string | `false` | no |

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Available targets:
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
-| environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance' | string | `LoadBalanced` | no |
+| environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time' and `updating_min_in_service` must be set to 0 | string | `LoadBalanced` | no |
 | force_destroy | Destroy S3 bucket for load balancer logs | string | `false` | no |
 | health_streaming_delete_on_terminate | Whether to delete the log group when the environment is terminated. If false, the health data is kept RetentionInDays days. | string | `false` | no |
 | health_streaming_enabled | For environments with enhanced health reporting enabled, whether to create a group in CloudWatch Logs for environment health and archive Elastic Beanstalk environment health data. For information about enabling enhanced health, see aws:elasticbeanstalk:healthreporting:system. | string | `false` | no |

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Available targets:
 | updating_min_in_service | Minimum count of instances up during update | string | `1` | no |
 | version_label | Elastic Beanstalk Application version to deploy | string | `` | no |
 | vpc_id | ID of the VPC in which to provision the AWS resources | string | - | yes |
-| wait_for_ready_timeout | - | string | `20m` | no |
+| wait_for_ready_timeout | The maximum duration that Terraform should wait for an Elastic Beanstalk Environment to be in a ready state before timing out. | string | `20m` | no |
 | zone_id | Route53 parent zone ID. The module will create sub-domain DNS records in the parent zone for the EB environment | string | `` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,6 +27,7 @@
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
+| environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance' | string | `LoadBalanced` | no |
 | force_destroy | Destroy S3 bucket for load balancer logs | string | `false` | no |
 | health_streaming_delete_on_terminate | Whether to delete the log group when the environment is terminated. If false, the health data is kept RetentionInDays days. | string | `false` | no |
 | health_streaming_enabled | For environments with enhanced health reporting enabled, whether to create a group in CloudWatch Logs for environment health and archive Elastic Beanstalk environment health data. For information about enabling enhanced health, see aws:elasticbeanstalk:healthreporting:system. | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -70,7 +70,7 @@
 | updating_min_in_service | Minimum count of instances up during update | string | `1` | no |
 | version_label | Elastic Beanstalk Application version to deploy | string | `` | no |
 | vpc_id | ID of the VPC in which to provision the AWS resources | string | - | yes |
-| wait_for_ready_timeout | - | string | `20m` | no |
+| wait_for_ready_timeout | The maximum duration that Terraform should wait for an Elastic Beanstalk Environment to be in a ready state before timing out. | string | `20m` | no |
 | zone_id | Route53 parent zone ID. The module will create sub-domain DNS records in the parent zone for the EB environment | string | `` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,7 +27,7 @@
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
-| environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time' and `updating_min_in_service` must be set to 0 | string | `LoadBalanced` | no |
+| environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time', `updating_min_in_service` must be set to 0, and `public_subnets` will be unused (it applies to the ELB, which does not exist in SingleInstance environments) | string | `LoadBalanced` | no |
 | force_destroy | Destroy S3 bucket for load balancer logs | string | `false` | no |
 | health_streaming_delete_on_terminate | Whether to delete the log group when the environment is terminated. If false, the health data is kept RetentionInDays days. | string | `false` | no |
 | health_streaming_enabled | For environments with enhanced health reporting enabled, whether to create a group in CloudWatch Logs for environment health and archive Elastic Beanstalk environment health data. For information about enabling enhanced health, see aws:elasticbeanstalk:healthreporting:system. | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,7 +27,7 @@
 | env_default_key | Default ENV variable key for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `DEFAULT_ENV_%d` | no |
 | env_default_value | Default ENV variable value for Elastic Beanstalk `aws:elasticbeanstalk:application:environment` setting | string | `UNSET` | no |
 | env_vars | Map of custom ENV variables to be provided to the Jenkins application running on Elastic Beanstalk, e.g. `env_vars = { JENKINS_USER = 'admin' JENKINS_PASS = 'xxxxxx' }` | map | `<map>` | no |
-| environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance' | string | `LoadBalanced` | no |
+| environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time' and `updating_min_in_service` must be set to 0 | string | `LoadBalanced` | no |
 | force_destroy | Destroy S3 bucket for load balancer logs | string | `false` | no |
 | health_streaming_delete_on_terminate | Whether to delete the log group when the environment is terminated. If false, the health data is kept RetentionInDays days. | string | `false` | no |
 | health_streaming_enabled | For environments with enhanced health reporting enabled, whether to create a group in CloudWatch Logs for environment health and archive Elastic Beanstalk environment health data. For information about enabling enhanced health, see aws:elasticbeanstalk:healthreporting:system. | string | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -441,39 +441,39 @@ resource "aws_elastic_beanstalk_environment" "default" {
   ###=========================== Autoscale trigger ========================== ###
 
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "MeasureName" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_measure_name : ""}"
+    namespace = "aws:autoscaling:trigger"
+    name      = "MeasureName"
+    value     = "${var.autoscale_measure_name}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "Statistic" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_statistic : ""}"
+    namespace = "aws:autoscaling:trigger"
+    name      = "Statistic"
+    value     = "${var.autoscale_statistic}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "Unit" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_unit : ""}"
+    namespace = "aws:autoscaling:trigger"
+    name      = "Unit"
+    value     = "${var.autoscale_unit}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "LowerThreshold" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_lower_bound : ""}"
+    namespace = "aws:autoscaling:trigger"
+    name      = "LowerThreshold"
+    value     = "${var.autoscale_lower_bound}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "LowerBreachScaleIncrement" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_lower_increment : ""}"
+    namespace = "aws:autoscaling:trigger"
+    name      = "LowerBreachScaleIncrement"
+    value     = "${var.autoscale_lower_increment}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "UpperThreshold" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_upper_bound : ""}"
+    namespace = "aws:autoscaling:trigger"
+    name      = "UpperThreshold"
+    value     = "${var.autoscale_upper_bound}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "UpperBreachScaleIncrement" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_upper_increment : ""}"
+    namespace = "aws:autoscaling:trigger"
+    name      = "UpperBreachScaleIncrement"
+    value     = "${var.autoscale_upper_increment}"
   }
 
   ###=========================== Autoscale trigger ========================== ###
@@ -521,132 +521,132 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "MinSize"
-    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_min : 1}"
+    value     = "${var.autoscale_min}"
   }
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "MaxSize"
-    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_max : 1}"
+    value     = "${var.autoscale_max}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "CrossZone" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? "true" : ""}"
+    namespace = "aws:elb:loadbalancer"
+    name      = "CrossZone"
+    value     = "true"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:loadbalancer" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "SecurityGroups" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? join(",", var.loadbalancer_security_groups) : ""}"
+    namespace = "aws:elb:loadbalancer"
+    name      = "SecurityGroups"
+    value     = "${join(",", var.loadbalancer_security_groups)}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:loadbalancer" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ManagedSecurityGroup" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_managed_security_group : ""}"
+    namespace = "aws:elb:loadbalancer"
+    name      = "ManagedSecurityGroup"
+    value     = "${var.loadbalancer_managed_security_group}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ListenerProtocol" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? "HTTP" : ""}"
+    namespace = "aws:elb:listener"
+    name      = "ListenerProtocol"
+    value     = "HTTP"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "InstancePort" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? "80" : ""}"
+    namespace = "aws:elb:listener"
+    name      = "InstancePort"
+    value     = "80"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ListenerEnabled" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? (var.http_listener_enabled  == "true" || var.loadbalancer_certificate_arn == "" ? "true" : "false") : ""}"
+    namespace = "aws:elb:listener"
+    name      = "ListenerEnabled"
+    value     = "${var.http_listener_enabled  == "true" || var.loadbalancer_certificate_arn == "" ? "true" : "false"}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener:443" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ListenerProtocol" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? "HTTPS" : ""}"
+    namespace = "aws:elb:listener:443"
+    name      = "ListenerProtocol"
+    value     = "HTTPS"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener:443" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "InstancePort" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? "80" : ""}"
+    namespace = "aws:elb:listener:443"
+    name      = "InstancePort"
+    value     = "80"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener:443" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "SSLCertificateId" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_certificate_arn : ""}"
+    namespace = "aws:elb:listener:443"
+    name      = "SSLCertificateId"
+    value     = "${var.loadbalancer_certificate_arn}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener:443" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ListenerEnabled" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_certificate_arn == "" ? "false" : "true" : ""}"
+    namespace = "aws:elb:listener:443"
+    name      = "ListenerEnabled"
+    value     = "${var.loadbalancer_certificate_arn == "" ? "false" : "true"}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? format("aws:elb:listener:%s", var.ssh_listener_port) : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ListenerProtocol" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? "TCP" : ""}"
+    namespace = "aws:elb:listener:${var.ssh_listener_port}"
+    name      = "ListenerProtocol"
+    value     = "TCP"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? format("aws:elb:listener:%s", var.ssh_listener_port) : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "InstancePort" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? "22" : ""}"
+    namespace = "aws:elb:listener:${var.ssh_listener_port}"
+    name      = "InstancePort"
+    value     = "22"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? format("aws:elb:listener:%s", var.ssh_listener_port) : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ListenerEnabled" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.ssh_listener_enabled : ""}"
+    namespace = "aws:elb:listener:${var.ssh_listener_port}"
+    name      = "ListenerEnabled"
+    value     = "${var.ssh_listener_enabled}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:policies" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ConnectionSettingIdleTimeout" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? (var.ssh_listener_enabled == "true" ? "3600" : "60") : ""}"
+    namespace = "aws:elb:policies"
+    name      = "ConnectionSettingIdleTimeout"
+    value     = "${var.ssh_listener_enabled == "true" ? "3600" : "60"}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:policies" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ConnectionDrainingEnabled" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? "true" : ""}"
+    namespace = "aws:elb:policies"
+    name      = "ConnectionDrainingEnabled"
+    value     = "true"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:loadbalancer" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "AccessLogsS3Bucket" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? aws_s3_bucket.elb_logs.id : ""}"
+    namespace = "aws:elbv2:loadbalancer"
+    name      = "AccessLogsS3Bucket"
+    value     = "${aws_s3_bucket.elb_logs.id}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:loadbalancer" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "AccessLogsS3Enabled" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? "true" : ""}"
+    namespace = "aws:elbv2:loadbalancer"
+    name      = "AccessLogsS3Enabled"
+    value     = "true"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:loadbalancer" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "SecurityGroups" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? join(",", var.loadbalancer_security_groups) : ""}"
+    namespace = "aws:elbv2:loadbalancer"
+    name      = "SecurityGroups"
+    value     = "${join(",", var.loadbalancer_security_groups)}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:loadbalancer" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ManagedSecurityGroup" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_managed_security_group : ""}"
+    namespace = "aws:elbv2:loadbalancer"
+    name      = "ManagedSecurityGroup"
+    value     = "${var.loadbalancer_managed_security_group}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:listener:default" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ListenerEnabled" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? (var.http_listener_enabled == "true" || var.loadbalancer_certificate_arn == "" ? "true" : "false") : ""}"
+    namespace = "aws:elbv2:listener:default"
+    name      = "ListenerEnabled"
+    value     = "${var.http_listener_enabled == "true" || var.loadbalancer_certificate_arn == "" ? "true" : "false"}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:listener:443" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "ListenerEnabled" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? (var.loadbalancer_certificate_arn == "" ? "false" : "true") : ""}"
+    namespace = "aws:elbv2:listener:443"
+    name      = "ListenerEnabled"
+    value     = "${var.loadbalancer_certificate_arn == "" ? "false" : "true"}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:listener:443" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "Protocol" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? "HTTPS" : ""}"
+    namespace = "aws:elbv2:listener:443"
+    name      = "Protocol"
+    value     = "HTTPS"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:listener:443" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "SSLCertificateArns" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_certificate_arn : ""}"
+    namespace = "aws:elbv2:listener:443"
+    name      = "SSLCertificateArns"
+    value     = "${var.loadbalancer_certificate_arn}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:listener:443" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "SSLPolicy" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? (var.loadbalancer_type == "application" ? var.loadbalancer_ssl_policy : "") : ""}"
+    namespace = "aws:elbv2:listener:443"
+    name      = "SSLPolicy"
+    value     = "${var.loadbalancer_type == "application" ? var.loadbalancer_ssl_policy : ""}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:healthreporting:system"
@@ -664,9 +664,9 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "${var.environment_type}"
   }
   setting {
-    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elasticbeanstalk:environment" : ""}"
-    name      = "${var.environment_type == "LoadBalanced" ? "LoadBalancerType" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_type : ""}"
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "LoadBalancerType"
+    value     = "${var.loadbalancer_type}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:environment"

--- a/main.tf
+++ b/main.tf
@@ -441,39 +441,39 @@ resource "aws_elastic_beanstalk_environment" "default" {
   ###=========================== Autoscale trigger ========================== ###
 
   setting {
-    namespace = "aws:autoscaling:trigger"
-    name      = "MeasureName"
-    value     = "${var.autoscale_measure_name}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "MeasureName" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_measure_name : ""}"
   }
   setting {
-    namespace = "aws:autoscaling:trigger"
-    name      = "Statistic"
-    value     = "${var.autoscale_statistic}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "Statistic" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_statistic : ""}"
   }
   setting {
-    namespace = "aws:autoscaling:trigger"
-    name      = "Unit"
-    value     = "${var.autoscale_unit}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "Unit" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_unit : ""}"
   }
   setting {
-    namespace = "aws:autoscaling:trigger"
-    name      = "LowerThreshold"
-    value     = "${var.autoscale_lower_bound}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "LowerThreshold" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_lower_bound : ""}"
   }
   setting {
-    namespace = "aws:autoscaling:trigger"
-    name      = "LowerBreachScaleIncrement"
-    value     = "${var.autoscale_lower_increment}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "LowerBreachScaleIncrement" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_lower_increment : ""}"
   }
   setting {
-    namespace = "aws:autoscaling:trigger"
-    name      = "UpperThreshold"
-    value     = "${var.autoscale_upper_bound}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "UpperThreshold" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_upper_bound : ""}"
   }
   setting {
-    namespace = "aws:autoscaling:trigger"
-    name      = "UpperBreachScaleIncrement"
-    value     = "${var.autoscale_upper_increment}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:autoscaling:trigger" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "UpperBreachScaleIncrement" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_upper_increment : ""}"
   }
 
   ###=========================== Autoscale trigger ========================== ###
@@ -521,132 +521,132 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "MinSize"
-    value     = "${var.autoscale_min}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_min : 1}"
   }
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "MaxSize"
-    value     = "${var.autoscale_max}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.autoscale_max : 1}"
   }
   setting {
-    namespace = "aws:elb:loadbalancer"
-    name      = "CrossZone"
-    value     = "true"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "CrossZone" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? "true" : ""}"
   }
   setting {
-    namespace = "aws:elb:loadbalancer"
-    name      = "SecurityGroups"
-    value     = "${join(",", var.loadbalancer_security_groups)}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:loadbalancer" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "SecurityGroups" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? join(",", var.loadbalancer_security_groups) : ""}"
   }
   setting {
-    namespace = "aws:elb:loadbalancer"
-    name      = "ManagedSecurityGroup"
-    value     = "${var.loadbalancer_managed_security_group}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:loadbalancer" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ManagedSecurityGroup" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_managed_security_group : ""}"
   }
   setting {
-    namespace = "aws:elb:listener"
-    name      = "ListenerProtocol"
-    value     = "HTTP"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ListenerProtocol" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? "HTTP" : ""}"
   }
   setting {
-    namespace = "aws:elb:listener"
-    name      = "InstancePort"
-    value     = "80"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "InstancePort" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? "80" : ""}"
   }
   setting {
-    namespace = "aws:elb:listener"
-    name      = "ListenerEnabled"
-    value     = "${var.http_listener_enabled  == "true" || var.loadbalancer_certificate_arn == "" ? "true" : "false"}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ListenerEnabled" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? (var.http_listener_enabled  == "true" || var.loadbalancer_certificate_arn == "" ? "true" : "false") : ""}"
   }
   setting {
-    namespace = "aws:elb:listener:443"
-    name      = "ListenerProtocol"
-    value     = "HTTPS"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener:443" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ListenerProtocol" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? "HTTPS" : ""}"
   }
   setting {
-    namespace = "aws:elb:listener:443"
-    name      = "InstancePort"
-    value     = "80"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener:443" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "InstancePort" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? "443" : ""}"
   }
   setting {
-    namespace = "aws:elb:listener:443"
-    name      = "SSLCertificateId"
-    value     = "${var.loadbalancer_certificate_arn}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener:443" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "SSLCertificateId" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_certificate_arn : ""}"
   }
   setting {
-    namespace = "aws:elb:listener:443"
-    name      = "ListenerEnabled"
-    value     = "${var.loadbalancer_certificate_arn == "" ? "false" : "true"}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener:443" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ListenerEnabled" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_certificate_arn == "" ? "false" : "true" : ""}"
   }
   setting {
-    namespace = "aws:elb:listener:${var.ssh_listener_port}"
-    name      = "ListenerProtocol"
-    value     = "TCP"
+    namespace = "${var.environment_type == "LoadBalanced" ? format("aws:elb:listener:%s", var.ssh_listener_port) : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ListenerProtocol" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? "TCP" : ""}"
   }
   setting {
-    namespace = "aws:elb:listener:${var.ssh_listener_port}"
-    name      = "InstancePort"
-    value     = "22"
+    namespace = "${var.environment_type == "LoadBalanced" ? format("aws:elb:listener:%s", var.ssh_listener_port) : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "InstancePort" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.ssh_listener_port : ""}"
   }
   setting {
-    namespace = "aws:elb:listener:${var.ssh_listener_port}"
-    name      = "ListenerEnabled"
-    value     = "${var.ssh_listener_enabled}"
+    namespace = "${var.environment_type == "LoadBalanced" ? format("aws:elb:listener:%s", var.ssh_listener_port) : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ListenerEnabled" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.ssh_listener_enabled : ""}"
   }
   setting {
-    namespace = "aws:elb:policies"
-    name      = "ConnectionSettingIdleTimeout"
-    value     = "${var.ssh_listener_enabled == "true" ? "3600" : "60"}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:policies" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ConnectionSettingIdleTimeout" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? (var.ssh_listener_enabled == "true" ? "3600" : "60") : ""}"
   }
   setting {
-    namespace = "aws:elb:policies"
-    name      = "ConnectionDrainingEnabled"
-    value     = "true"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:policies" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ConnectionDrainingEnabled" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? "true" : ""}"
   }
   setting {
-    namespace = "aws:elbv2:loadbalancer"
-    name      = "AccessLogsS3Bucket"
-    value     = "${aws_s3_bucket.elb_logs.id}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:loadbalancer" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "AccessLogsS3Bucket" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? aws_s3_bucket.elb_logs.id : ""}"
   }
   setting {
-    namespace = "aws:elbv2:loadbalancer"
-    name      = "AccessLogsS3Enabled"
-    value     = "true"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:loadbalancer" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "AccessLogsS3Enabled" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? "true" : ""}"
   }
   setting {
-    namespace = "aws:elbv2:loadbalancer"
-    name      = "SecurityGroups"
-    value     = "${join(",", var.loadbalancer_security_groups)}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:loadbalancer" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "SecurityGroups" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? join(",", var.loadbalancer_security_groups) : ""}"
   }
   setting {
-    namespace = "aws:elbv2:loadbalancer"
-    name      = "ManagedSecurityGroup"
-    value     = "${var.loadbalancer_managed_security_group}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:loadbalancer" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ManagedSecurityGroup" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_managed_security_group : ""}"
   }
   setting {
-    namespace = "aws:elbv2:listener:default"
-    name      = "ListenerEnabled"
-    value     = "${var.http_listener_enabled == "true" || var.loadbalancer_certificate_arn == "" ? "true" : "false"}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:listener:default" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ListenerEnabled" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? (var.http_listener_enabled == "true" || var.loadbalancer_certificate_arn == "" ? "true" : "false") : ""}"
   }
   setting {
-    namespace = "aws:elbv2:listener:443"
-    name      = "ListenerEnabled"
-    value     = "${var.loadbalancer_certificate_arn == "" ? "false" : "true"}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:listener:443" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "ListenerEnabled" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? (var.loadbalancer_certificate_arn == "" ? "false" : "true") : ""}"
   }
   setting {
-    namespace = "aws:elbv2:listener:443"
-    name      = "Protocol"
-    value     = "HTTPS"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:listener:443" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "Protocol" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? "HTTPS" : ""}"
   }
   setting {
-    namespace = "aws:elbv2:listener:443"
-    name      = "SSLCertificateArns"
-    value     = "${var.loadbalancer_certificate_arn}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:listener:443" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "SSLCertificateArns" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_certificate_arn : ""}"
   }
   setting {
-    namespace = "aws:elbv2:listener:443"
-    name      = "SSLPolicy"
-    value     = "${var.loadbalancer_type == "application" ? var.loadbalancer_ssl_policy : ""}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elbv2:listener:443" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "SSLPolicy" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? (var.loadbalancer_type == "application" ? var.loadbalancer_ssl_policy : "") : ""}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:healthreporting:system"
@@ -664,9 +664,9 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "${var.environment_type}"
   }
   setting {
-    namespace = "aws:elasticbeanstalk:environment"
-    name      = "LoadBalancerType"
-    value     = "${var.loadbalancer_type}"
+    namespace = "${var.environment_type == "LoadBalanced" ? "aws:elasticbeanstalk:environment" : ""}"
+    name      = "${var.environment_type == "LoadBalanced" ? "LoadBalancerType" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? var.loadbalancer_type : ""}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:environment"

--- a/main.tf
+++ b/main.tf
@@ -566,7 +566,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener:443" : ""}"
     name      = "${var.environment_type == "LoadBalanced" ? "InstancePort" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? "443" : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? "80" : ""}"
   }
   setting {
     namespace = "${var.environment_type == "LoadBalanced" ? "aws:elb:listener:443" : ""}"
@@ -586,7 +586,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "${var.environment_type == "LoadBalanced" ? format("aws:elb:listener:%s", var.ssh_listener_port) : ""}"
     name      = "${var.environment_type == "LoadBalanced" ? "InstancePort" : ""}"
-    value     = "${var.environment_type == "LoadBalanced" ? var.ssh_listener_port : ""}"
+    value     = "${var.environment_type == "LoadBalanced" ? "22" : ""}"
   }
   setting {
     namespace = "${var.environment_type == "LoadBalanced" ? format("aws:elb:listener:%s", var.ssh_listener_port) : ""}"

--- a/main.tf
+++ b/main.tf
@@ -660,6 +660,11 @@ resource "aws_elastic_beanstalk_environment" "default" {
   }
   setting {
     namespace = "aws:elasticbeanstalk:environment"
+    name      = "EnvironmentType"
+    value     = "${var.environment_type}}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
     name      = "LoadBalancerType"
     value     = "${var.loadbalancer_type}"
   }

--- a/main.tf
+++ b/main.tf
@@ -661,7 +661,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:elasticbeanstalk:environment"
     name      = "EnvironmentType"
-    value     = "${var.environment_type}}"
+    value     = "${var.environment_type}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:environment"

--- a/variables.tf
+++ b/variables.tf
@@ -102,7 +102,7 @@ variable "logs_retention_in_days" {
 
 variable "environment_type" {
   default     = "LoadBalanced"
-  description = "Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be changed to 'Time'"
+  description = "Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time' and `updating_min_in_service` must be set to 0"
 }
 
 variable "loadbalancer_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -100,6 +100,11 @@ variable "logs_retention_in_days" {
   description = "The number of days to keep log events before they expire."
 }
 
+variable "environment_type" {
+  default     = "LoadBalanced"
+  description = "Environment type, e.g. 'LoadBalanced' or 'SingleInstance'"
+}
+
 variable "loadbalancer_type" {
   default     = "classic"
   description = "Load Balancer type, e.g. 'application' or 'classic'"

--- a/variables.tf
+++ b/variables.tf
@@ -102,7 +102,7 @@ variable "logs_retention_in_days" {
 
 variable "environment_type" {
   default     = "LoadBalanced"
-  description = "Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time' and `updating_min_in_service` must be set to 0"
+  description = "Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time', `updating_min_in_service` must be set to 0, and `public_subnets` will be unused (it applies to the ELB, which does not exist in SingleInstance environments)"
 }
 
 variable "loadbalancer_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -300,7 +300,8 @@ variable "solution_stack_name" {
 }
 
 variable "wait_for_ready_timeout" {
-  default = "20m"
+  default     = "20m"
+  description = "The maximum duration that Terraform should wait for an Elastic Beanstalk Environment to be in a ready state before timing out."
 }
 
 # From: http://docs.aws.amazon.com/general/latest/gr/rande.html#elasticbeanstalk_region

--- a/variables.tf
+++ b/variables.tf
@@ -102,7 +102,7 @@ variable "logs_retention_in_days" {
 
 variable "environment_type" {
   default     = "LoadBalanced"
-  description = "Environment type, e.g. 'LoadBalanced' or 'SingleInstance'"
+  description = "Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be changed to 'Time'"
 }
 
 variable "loadbalancer_type" {


### PR DESCRIPTION
There are two types of beanstalk, LoadBalanced and SingleInstance.  Not entirely sure if the SingleInstance type is ever a great choice, but I use it sometimes for when I want the ElasticBeanstalk infrastructure sugar without the horizontal scaling, e.g. right now for running a slackbot