### PR TITLE
These look like typos to me

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -565,7 +565,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:elb:listener:443"
     name      = "InstancePort"
-    value     = "80"
+    value     = "443"
   }
   setting {
     namespace = "aws:elb:listener:443"
@@ -585,7 +585,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:elb:listener:${var.ssh_listener_port}"
     name      = "InstancePort"
-    value     = "22"
+    value     = "${var.ssh_listener_port}"
   }
   setting {
     namespace = "aws:elb:listener:${var.ssh_listener_port}"


### PR DESCRIPTION
I can see why I might be wrong, `InstancePort` is for the instances I guess, does EB always ensure they listen on those exact ports and it's not configurable?  The idea of SSHing to the loadbalancer is a bit weird to me tho