### PR TITLE
Allow setting elb_scheme for choosing internal or public LB

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -544,6 +544,11 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "${var.loadbalancer_managed_security_group}"
   }
   setting {
+    namespace = "aws:ec2:vpc"
+    name = "ELBScheme"
+    value = "${var.environment_type == "LoadBalanced" ? var.elb_scheme : ""}"
+  }
+  setting {
     namespace = "aws:elb:listener"
     name      = "ListenerProtocol"
     value     = "HTTP"

--- a/variables.tf
+++ b/variables.tf
@@ -371,3 +371,9 @@ variable "force_destroy" {
   default     = false
   description = "Destroy S3 bucket for load balancer logs"
 }
+
+variable "elb_scheme" {
+  default = "internal"
+  description = "Whether the load balancer should be 'internal' or 'public'"
+}
+


### PR DESCRIPTION
Have tested with load balanced environment, but not SingleInstance.

Terraform wants to update the settings on the environment every time, even with no changes (and even using the module from `master`), is this normal?