### PR TITLE
Allow setting elb_scheme for choosing internal or public LB

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Available targets:
 | config_source | S3 source for config | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | description | Short description of the Environment | string | `` | no |
+| elb_scheme | Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC | string | `` | no |
 | enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application. | string | `false` | no |
 | enable_managed_actions | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | string | `true` | no |
 | enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment. | string | `false` | no |

--- a/README.md
+++ b/README.md
@@ -298,8 +298,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Guillaume Delacour][guikcd_avatar]][guikcd_homepage]<br/>[Guillaume Delacour][guikcd_homepage] | [![Viktor Erpylev][velmoga_avatar]][velmoga_homepage]<br/>[Viktor Erpylev][velmoga_homepage] | [![Lucas Pearson][pearson-lucas-dev_avatar]][pearson-lucas-dev_homepage]<br/>[Lucas Pearson][pearson-lucas-dev_homepage] |
-|---|---|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Guillaume Delacour][guikcd_avatar]][guikcd_homepage]<br/>[Guillaume Delacour][guikcd_homepage] | [![Viktor Erpylev][velmoga_avatar]][velmoga_homepage]<br/>[Viktor Erpylev][velmoga_homepage] | [![Lucas Pearson][pearson-lucas-dev_avatar]][pearson-lucas-dev_homepage]<br/>[Lucas Pearson][pearson-lucas-dev_homepage] | [![Chris Green][DirectRoot_avatar]][DirectRoot_homepage]<br/>[Chris Green][DirectRoot_homepage] |
+|---|---|---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://github.com/osterman.png?size=150
@@ -313,6 +313,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [velmoga_avatar]: https://github.com/velmoga.png?size=150
   [pearson-lucas-dev_homepage]: https://github.com/pearson-lucas-dev
   [pearson-lucas-dev_avatar]: https://github.com/pearson-lucas-dev.png?size=150
+  [DirectRoot_homepage]: https://github.com/DirectRoot
+  [DirectRoot_avatar]: https://github.com/DirectRoot.png?size=150
 
 
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Available targets:
 | config_source | S3 source for config | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | description | Short description of the Environment | string | `` | no |
-| elb_scheme | Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC | string | `` | no |
+| elb_scheme | Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC | string | `public` | no |
 | enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application. | string | `false` | no |
 | enable_managed_actions | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | string | `true` | no |
 | enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment. | string | `false` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -81,3 +81,5 @@ contributors:
     github: "velmoga"
   - name: "Lucas Pearson"
     github: "pearson-lucas-dev"
+  - name: "Chris Green"
+    github: "DirectRoot"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -20,7 +20,7 @@
 | config_source | S3 source for config | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | description | Short description of the Environment | string | `` | no |
-| elb_scheme | Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC | string | `` | no |
+| elb_scheme | Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC | string | `public` | no |
 | enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application. | string | `false` | no |
 | enable_managed_actions | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | string | `true` | no |
 | enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment. | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -20,6 +20,7 @@
 | config_source | S3 source for config | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | description | Short description of the Environment | string | `` | no |
+| elb_scheme | Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC | string | `` | no |
 | enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application. | string | `false` | no |
 | enable_managed_actions | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | string | `true` | no |
 | enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment. | string | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -544,6 +544,11 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "${var.loadbalancer_managed_security_group}"
   }
   setting {
+    namespace = "aws:ec2:vpc"
+    name = "ELBScheme"
+    value = "${var.environment_type == "LoadBalanced" ? var.elb_scheme : ""}"
+  }
+  setting {
     namespace = "aws:elb:listener"
     name      = "ListenerProtocol"
     value     = "HTTP"

--- a/main.tf
+++ b/main.tf
@@ -545,8 +545,8 @@ resource "aws_elastic_beanstalk_environment" "default" {
   }
   setting {
     namespace = "aws:ec2:vpc"
-    name = "ELBScheme"
-    value = "${var.environment_type == "LoadBalanced" ? var.elb_scheme : ""}"
+    name      = "ELBScheme"
+    value     = "${var.environment_type == "LoadBalanced" ? var.elb_scheme : ""}"
   }
   setting {
     namespace = "aws:elb:listener"

--- a/variables.tf
+++ b/variables.tf
@@ -373,6 +373,6 @@ variable "force_destroy" {
 }
 
 variable "elb_scheme" {
-  default     = "internal"
+  default     = ""
   description = "Whether the load balancer should be 'internal' or 'public'"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -374,5 +374,5 @@ variable "force_destroy" {
 
 variable "elb_scheme" {
   default     = ""
-  description = "Whether the load balancer should be 'internal' or 'public'"
+  description = "Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -373,6 +373,6 @@ variable "force_destroy" {
 }
 
 variable "elb_scheme" {
-  default     = ""
+  default     = "public"
   description = "Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -371,3 +371,9 @@ variable "force_destroy" {
   default     = false
   description = "Destroy S3 bucket for load balancer logs"
 }
+
+variable "elb_scheme" {
+  default = "internal"
+  description = "Whether the load balancer should be 'internal' or 'public'"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -373,7 +373,6 @@ variable "force_destroy" {
 }
 
 variable "elb_scheme" {
-  default = "internal"
+  default     = "internal"
   description = "Whether the load balancer should be 'internal' or 'public'"
 }
-


### PR DESCRIPTION
Have tested with load balanced environment, but not SingleInstance.

Terraform wants to update the settings on the environment every time, even with no changes (and even using the module from `master`), is this normal?