### PR TITLE
Add `env_vars` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Available targets:
 | enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application | bool | `false` | no |
 | enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment | bool | `false` | no |
 | enhanced_reporting_enabled | Whether to enable "enhanced" health reporting for this environment.  If false, "basic" reporting is used.  When you set this to false, you must also set `enable_managed_actions` to false | bool | `true` | no |
+| env_vars | Map of custom ENV variables to be provided to the application running on Elastic Beanstalk, e.g. env_vars = { DB_USER = 'admin' DB_PASS = 'xxxxxx' } | map(string) | `<map>` | no |
 | environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time', `updating_min_in_service` must be set to 0, and `loadbalancer_subnets` will be unused (it applies to the ELB, which does not exist in SingleInstance environments) | string | `LoadBalanced` | no |
 | force_destroy | Force destroy the S3 bucket for load balancer logs | bool | `false` | no |
 | health_streaming_delete_on_terminate | Whether to delete the log group when the environment is terminated. If false, the health data is kept RetentionInDays days. | bool | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,6 +27,7 @@
 | enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application | bool | `false` | no |
 | enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment | bool | `false` | no |
 | enhanced_reporting_enabled | Whether to enable "enhanced" health reporting for this environment.  If false, "basic" reporting is used.  When you set this to false, you must also set `enable_managed_actions` to false | bool | `true` | no |
+| env_vars | Map of custom ENV variables to be provided to the application running on Elastic Beanstalk, e.g. env_vars = { DB_USER = 'admin' DB_PASS = 'xxxxxx' } | map(string) | `<map>` | no |
 | environment_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time', `updating_min_in_service` must be set to 0, and `loadbalancer_subnets` will be unused (it applies to the ELB, which does not exist in SingleInstance environments) | string | `LoadBalanced` | no |
 | force_destroy | Force destroy the S3 bucket for load balancer logs | bool | `false` | no |
 | health_streaming_delete_on_terminate | Whether to delete the log group when the environment is terminated. If false, the health data is kept RetentionInDays days. | bool | `false` | no |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -80,26 +80,12 @@ additional_settings = [
     namespace = "aws:elasticbeanstalk:managedactions"
     name      = "ManagedActionsEnabled"
     value     = "false"
-  },
-  // Environment variables
-  {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "DB_HOST"
-    value     = "xxxxxxxxxxxxxx"
-  },
-  {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "DB_USERNAME"
-    value     = "yyyyyyyyyyyyy"
-  },
-  {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "DB_PASSWORD"
-    value     = "zzzzzzzzzzzzzzzzzzz"
-  },
-  {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "ANOTHER_ENV_VAR"
-    value     = "123456789"
   }
 ]
+
+env_vars = {
+  "DB_HOST"         = "xxxxxxxxxxxxxx"
+  "DB_USERNAME"     = "yyyyyyyyyyyyy"
+  "DB_PASSWORD"     = "zzzzzzzzzzzzzzzzzzz"
+  "ANOTHER_ENV_VAR" = "123456789"
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -94,4 +94,5 @@ module "elastic_beanstalk_environment" {
   solution_stack_name = var.solution_stack_name
 
   additional_settings = var.additional_settings
+  env_vars            = var.env_vars
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -196,3 +196,9 @@ variable "additional_settings" {
   description = "Additional Elastic Beanstalk setttings. For full list of options, see https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html"
   default     = []
 }
+
+variable "env_vars" {
+  type        = map(string)
+  default     = {}
+  description = "Map of custom ENV variables to be provided to the application running on Elastic Beanstalk, e.g. env_vars = { DB_USER = 'admin' DB_PASS = 'xxxxxx' }"
+}

--- a/main.tf
+++ b/main.tf
@@ -772,6 +772,16 @@ resource "aws_elastic_beanstalk_environment" "default" {
       value     = setting.value.value
     }
   }
+
+  // Add environment variables if provided
+  dynamic "setting" {
+    for_each = var.env_vars
+    content {
+      namespace = "aws:elasticbeanstalk:application:environment"
+      name      = setting.key
+      value     = setting.value
+    }
+  }
 }
 
 data "aws_elb_service_account" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -381,6 +381,12 @@ variable "additional_settings" {
   description = "Additional Elastic Beanstalk setttings. For full list of options, see https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html"
 }
 
+variable "env_vars" {
+  type        = map(string)
+  default     = {}
+  description = "Map of custom ENV variables to be provided to the application running on Elastic Beanstalk, e.g. env_vars = { DB_USER = 'admin' DB_PASS = 'xxxxxx' }"
+}
+
 # From: http://docs.aws.amazon.com/general/latest/gr/rande.html#elasticbeanstalk_region
 # Via: https://github.com/hashicorp/terraform/issues/7071
 variable "alb_zone_id" {


### PR DESCRIPTION
## what
* Add `env_vars` variable

## why
* Make it easier for the clients to provide ENV vars (as a map of key/value pairs) to the applications running on Elastic Beanstalk instead of providing ENV vars in the more complicated `setting` block
