### PR TITLE
Adds `dns_subdomain` var to control final hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Available targets:
 | availability_zone_selector | Availability Zone selector | string | `Any 2` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | description | Short description of the Environment | string | `` | no |
+| dns_subdomain | The subdomain to create on Route53 for the EB environment. For the subdomain to be created, the `dns_zone_id` variable must be set as well | string | `` | no |
 | dns_zone_id | Route53 parent zone ID. The module will create sub-domain DNS record in the parent zone for the EB environment | string | `` | no |
 | elastic_beanstalk_application_name | Elastic Beanstalk application name | string | - | yes |
 | elb_scheme | Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC | string | `public` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,6 +21,7 @@
 | availability_zone_selector | Availability Zone selector | string | `Any 2` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | description | Short description of the Environment | string | `` | no |
+| dns_subdomain | The subdomain to create on Route53 for the EB environment. For the subdomain to be created, the `dns_zone_id` variable must be set as well | string | `` | no |
 | dns_zone_id | Route53 parent zone ID. The module will create sub-domain DNS record in the parent zone for the EB environment | string | `` | no |
 | elastic_beanstalk_application_name | Elastic Beanstalk application name | string | - | yes |
 | elb_scheme | Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC | string | `public` | no |

--- a/main.tf
+++ b/main.tf
@@ -823,7 +823,7 @@ resource "aws_s3_bucket" "elb_logs" {
 module "dns_hostname" {
   source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.3.0"
   enabled = var.dns_zone_id != "" && var.tier == "WebServer" ? true : false
-  name    = var.name
+  name    = var.dns_subdomain != "" ? var.dns_subdomain : var.name
   zone_id = var.dns_zone_id
   records = [aws_elastic_beanstalk_environment.default.cname]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,12 @@ variable "dns_zone_id" {
   description = "Route53 parent zone ID. The module will create sub-domain DNS record in the parent zone for the EB environment"
 }
 
+variable "dns_subdomain" {
+  type        = string
+  default     = ""
+  description = "The subdomain to create on Route53 for the EB environment. For the subdomain to be created, the `dns_zone_id` variable must be set as well"
+}
+
 variable "allowed_security_groups" {
   type        = list(string)
   description = "List of security groups to be allowed to connect to the EC2 instances"


### PR DESCRIPTION
`dns_subdomain` allows a more customized name than the default `name` provided so consumers can scope their subdomains by environment or other custom needs.