### PR TITLE
feat: add support for ami_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Available targets:
 | additional_settings | Additional Elastic Beanstalk setttings. For full list of options, see https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html | object | `<list>` | no |
 | alb_zone_id | ALB zone id | map(string) | `<map>` | no |
 | allowed_security_groups | List of security groups to add to the EC2 instances | list(string) | `<list>` | no |
+| ami_id | The id of the AMI to associate with the Amazon EC2 instances | string | `` | no |
 | application_port | Port application is listening on | number | `80` | no |
 | application_subnets | List of subnets to place EC2 instances | list(string) | - | yes |
 | associate_public_ip_address | Whether to associate public IP addresses to the instances | bool | `false` | no |

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Available targets:
 | additional_settings | Additional Elastic Beanstalk setttings. For full list of options, see https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html | object | `<list>` | no |
 | alb_zone_id | ALB zone id | map(string) | `<map>` | no |
 | allowed_security_groups | List of security groups to add to the EC2 instances | list(string) | `<list>` | no |
-| ami_id | The id of the AMI to associate with the Amazon EC2 instances | string | `` | no |
+| ami_id | The id of the AMI to associate with the Amazon EC2 instances | string | `null` | no |
 | application_port | Port application is listening on | number | `80` | no |
 | application_subnets | List of subnets to place EC2 instances | list(string) | - | yes |
 | associate_public_ip_address | Whether to associate public IP addresses to the instances | bool | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,6 +6,7 @@
 | additional_settings | Additional Elastic Beanstalk setttings. For full list of options, see https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html | object | `<list>` | no |
 | alb_zone_id | ALB zone id | map(string) | `<map>` | no |
 | allowed_security_groups | List of security groups to add to the EC2 instances | list(string) | `<list>` | no |
+| ami_id | The id of the AMI to associate with the Amazon EC2 instances | string | `` | no |
 | application_port | Port application is listening on | number | `80` | no |
 | application_subnets | List of subnets to place EC2 instances | list(string) | - | yes |
 | associate_public_ip_address | Whether to associate public IP addresses to the instances | bool | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,7 +6,7 @@
 | additional_settings | Additional Elastic Beanstalk setttings. For full list of options, see https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html | object | `<list>` | no |
 | alb_zone_id | ALB zone id | map(string) | `<map>` | no |
 | allowed_security_groups | List of security groups to add to the EC2 instances | list(string) | `<list>` | no |
-| ami_id | The id of the AMI to associate with the Amazon EC2 instances | string | `` | no |
+| ami_id | The id of the AMI to associate with the Amazon EC2 instances | string | `null` | no |
 | application_port | Port application is listening on | number | `80` | no |
 | application_subnets | List of subnets to place EC2 instances | list(string) | - | yes |
 | associate_public_ip_address | Whether to associate public IP addresses to the instances | bool | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -700,10 +700,13 @@ resource "aws_elastic_beanstalk_environment" "default" {
     resource  = ""
   }
 
-  setting {
-    namespace = "aws:autoscaling:launchconfiguration"
-    name      = "ImageId"
-    value     = "${var.ami_id}"
+  dynamic "setting" {
+    for_each = var.ami_id == null ? [] : [var.ami_id]
+    content {
+      namespace = "aws:autoscaling:launchconfiguration"
+      name      = "ImageId"
+      value     = setting.value
+    }
   }
 
   setting {

--- a/main.tf
+++ b/main.tf
@@ -646,6 +646,12 @@ resource "aws_elastic_beanstalk_environment" "default" {
   }
 
   setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "ImageId"
+    value     = "${var.ami_id}"
+  }
+
+  setting {
     namespace = "aws:elasticbeanstalk:command"
     name      = "BatchSizeType"
     value     = "Fixed"

--- a/variables.tf
+++ b/variables.tf
@@ -424,3 +424,9 @@ variable "alb_zone_id" {
 
   description = "ALB zone id"
 }
+
+variable "ami_id" {
+  type = string
+  default = ""
+  description = "The id of the AMI to associate with the Amazon EC2 instances"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -456,7 +456,7 @@ variable "alb_zone_id" {
 }
 
 variable "ami_id" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The id of the AMI to associate with the Amazon EC2 instances"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -457,6 +457,6 @@ variable "alb_zone_id" {
 
 variable "ami_id" {
   type        = string
-  default     = ""
+  default     = null
   description = "The id of the AMI to associate with the Amazon EC2 instances"
 }


### PR DESCRIPTION
## what

* Added support for specifying `ami_id`

## why
* `ami_id` is a key configurable option in EB environments

## references
* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html