### PR TITLE
Allow use of existing IAM role for EC2 instance profile

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -123,6 +123,7 @@ usage: |-
       loadbalancer_subnets    = module.subnets.public_subnet_ids
       application_subnets     = module.subnets.private_subnet_ids
       allowed_security_groups = [module.vpc.vpc_default_security_group_id]
+      instance_role_name      = aws_iam.role.ec2_instance_role.name
 
       // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html
       // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.docker

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -39,7 +39,7 @@
 | healthcheck_url | Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances | string | `/healthcheck` | no |
 | http_listener_enabled | Enable port 80 (http) | bool | `true` | no |
 | instance_refresh_enabled | Enable weekly instance replacement. | bool | `true` | no |
-| instance_role_name | I | string | `` | no |
+| instance_role_name | Instance role name of existing IAM role to attach to Beanstalk deployment | string | `` | no |
 | instance_type | Instances type | string | `t2.micro` | no |
 | keypair | Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS | string | `` | no |
 | loadbalancer_certificate_arn | Load Balancer SSL certificate ARN. The certificate must be present in AWS Certificate Manager | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -39,6 +39,7 @@
 | healthcheck_url | Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances | string | `/healthcheck` | no |
 | http_listener_enabled | Enable port 80 (http) | bool | `true` | no |
 | instance_refresh_enabled | Enable weekly instance replacement. | bool | `true` | no |
+| instance_role_name | I | string | `` | no |
 | instance_type | Instances type | string | `t2.micro` | no |
 | keypair | Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS | string | `` | no |
 | loadbalancer_certificate_arn | Load Balancer SSL certificate ARN. The certificate must be present in AWS Certificate Manager | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -554,7 +554,6 @@ resource "aws_elastic_beanstalk_environment" "default" {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "IamInstanceProfile"
     value     = var.instance_role_name == "" ? join("", aws_iam_instance_profile.ec2.*.name) : var.instance_role_name
-    #value     = aws_iam_instance_profile.ec2.name
   }
 
   setting {
@@ -573,7 +572,6 @@ resource "aws_elastic_beanstalk_environment" "default" {
     namespace = "aws:elasticbeanstalk:environment"
     name      = "ServiceRole"
     value     = var.service_role_name == "" ? join("", aws_iam_role.service.*.name) : var.service_role_name
-    #value     = aws_iam_role.service.name
   }
 
   setting {

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,7 @@ output "elb_zone_id" {
 }
 
 output "ec2_instance_profile_role_name" {
-  value       = aws_iam_role.ec2.name
+  value       = var.instance_role_name == "" ? join("", aws_iam_role.ec2.*.name) : var.instance_role_name
   description = "Instance IAM role name"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -430,3 +430,15 @@ variable "alb_zone_id" {
 
   description = "ALB zone id"
 }
+
+variable "instance_role_name" {
+  type        = string
+  default     = ""
+  description = "Instance role name of existing IAM role to attach to Beanstalk deployment"
+}
+
+variable "service_role_name" {
+  type        = string
+  default     = ""
+  description = "Service role name of existing IAM role to attach to Beanstalk deployment"
+}


### PR DESCRIPTION
## What
* Enhancement of #107 , due to original developer seemingly abandoning the original PR.
    * Adds `service_role_name` as another 'override', like `instance_role_name` is in the original PR. 
* Allow the user of the module to specify an existing IAM Role name for the instance profile.
* Allow the user of the module to specify an existing IAM Role name for the service profile.
* This IAM role name will be used to create the instance profile that is assigned to the EC2 instances managed by Elastic Beanstalk.

## Why
* Some environments/users do not have the ability to create their own IAM roles/policies, for security reasons.  This change allows a user to provide their own IAM role if one already exists.
* Currently the module creates an IAM role and a series of permissions for the role.
* It is not possible to specify what permissions to use
* It is not possible to edit the permissions that are created
* This limitation severely limits the capability of the EC2 instances if they require other permissions to operate.

## References
* closes #70 
* closes #107
