### PR TITLE
Add support for spot instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Available targets:
 | elastic_beanstalk_application_name | Elastic Beanstalk application name | string | - | yes |
 | elb_scheme | Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC | string | `public` | no |
 | enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application | bool | `false` | no |
+| enable_spot_instances | Enable Spot Instance requests for your environment | bool | `false` | no |
 | enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment | bool | `false` | no |
 | enhanced_reporting_enabled | Whether to enable "enhanced" health reporting for this environment.  If false, "basic" reporting is used.  When you set this to false, you must also set `enable_managed_actions` to false | bool | `true` | no |
 | env_vars | Map of custom ENV variables to be provided to the application running on Elastic Beanstalk, e.g. env_vars = { DB_USER = 'admin' DB_PASS = 'xxxxxx' } | map(string) | `<map>` | no |
@@ -254,6 +255,9 @@ Available targets:
 | root_volume_size | The size of the EBS root volume | number | `8` | no |
 | root_volume_type | The type of the EBS root volume | string | `gp2` | no |
 | solution_stack_name | Elastic Beanstalk stack, e.g. Docker, Go, Node, Java, IIS. For more info, see https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html | string | - | yes |
+| spot_fleet_on_demand_above_base_percentage | The percentage of On-Demand Instances as part of additional capacity that your Auto Scaling group provisions beyond the SpotOnDemandBase instances. This option is relevant only when enable_spot_instances is true. | number | `-1` | no |
+| spot_fleet_on_demand_base | The minimum number of On-Demand Instances that your Auto Scaling group provisions before considering Spot Instances as your environment scales up. This option is relevant only when enable_spot_instances is true. | number | `0` | no |
+| spot_max_price | The maximum price per unit hour, in US$, that you're willing to pay for a Spot Instance. This option is relevant only when enable_spot_instances is true. Valid values are between 0.001 and 20.0 | number | `-1` | no |
 | ssh_listener_enabled | Enable SSH port | bool | `false` | no |
 | ssh_listener_port | SSH port | number | `22` | no |
 | ssh_source_restriction | Used to lock down SSH access to the EC2 instances | string | `0.0.0.0/0` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,6 +27,7 @@
 | elastic_beanstalk_application_name | Elastic Beanstalk application name | string | - | yes |
 | elb_scheme | Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC | string | `public` | no |
 | enable_log_publication_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application | bool | `false` | no |
+| enable_spot_instances | Enable Spot Instance requests for your environment | bool | `false` | no |
 | enable_stream_logs | Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment | bool | `false` | no |
 | enhanced_reporting_enabled | Whether to enable "enhanced" health reporting for this environment.  If false, "basic" reporting is used.  When you set this to false, you must also set `enable_managed_actions` to false | bool | `true` | no |
 | env_vars | Map of custom ENV variables to be provided to the application running on Elastic Beanstalk, e.g. env_vars = { DB_USER = 'admin' DB_PASS = 'xxxxxx' } | map(string) | `<map>` | no |
@@ -59,6 +60,9 @@
 | root_volume_size | The size of the EBS root volume | number | `8` | no |
 | root_volume_type | The type of the EBS root volume | string | `gp2` | no |
 | solution_stack_name | Elastic Beanstalk stack, e.g. Docker, Go, Node, Java, IIS. For more info, see https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html | string | - | yes |
+| spot_fleet_on_demand_above_base_percentage | The percentage of On-Demand Instances as part of additional capacity that your Auto Scaling group provisions beyond the SpotOnDemandBase instances. This option is relevant only when enable_spot_instances is true. | number | `-1` | no |
+| spot_fleet_on_demand_base | The minimum number of On-Demand Instances that your Auto Scaling group provisions before considering Spot Instances as your environment scales up. This option is relevant only when enable_spot_instances is true. | number | `0` | no |
+| spot_max_price | The maximum price per unit hour, in US$, that you're willing to pay for a Spot Instance. This option is relevant only when enable_spot_instances is true. Valid values are between 0.001 and 20.0 | number | `-1` | no |
 | ssh_listener_enabled | Enable SSH port | bool | `false` | no |
 | ssh_listener_port | SSH port | number | `22` | no |
 | ssh_source_restriction | Used to lock down SSH access to the EC2 instances | string | `0.0.0.0/0` | no |

--- a/main.tf
+++ b/main.tf
@@ -623,9 +623,33 @@ resource "aws_elastic_beanstalk_environment" "default" {
   }
 
   setting {
-    namespace = "aws:autoscaling:launchconfiguration"
-    name      = "InstanceType"
+    namespace = "aws:ec2:instances"
+    name      = "InstanceTypes"
     value     = var.instance_type
+  }
+
+  setting {
+    namespace = "aws:ec2:instances"
+    name      = "EnableSpot"
+    value     = var.enable_spot_instances ? "true" : "false"
+  }
+
+  setting {
+    namespace = "aws:ec2:instances"
+    name      = "SpotFleetOnDemandBase"
+    value     = var.spot_fleet_on_demand_base
+  }
+
+  setting {
+    namespace = "aws:ec2:instances"
+    name      = "SpotFleetOnDemandAboveBasePercentage"
+    value     = var.spot_fleet_on_demand_above_base_percentage == -1 ? (var.environment_type == "LoadBalanced" ? 70 : 0) : var.spot_fleet_on_demand_above_base_percentage
+  }
+
+  setting {
+    namespace = "aws:ec2:instances"
+    name      = "SpotMaxPrice"
+    value     = var.spot_max_price == -1 ? "null" : var.spot_max_price
   }
 
   setting {

--- a/variables.tf
+++ b/variables.tf
@@ -120,26 +120,26 @@ variable "instance_type" {
 }
 
 variable "enable_spot_instances" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable Spot Instance requests for your environment"
 }
 
 variable "spot_fleet_on_demand_base" {
-  type = number
-  default = 0
+  type        = number
+  default     = 0
   description = "The minimum number of On-Demand Instances that your Auto Scaling group provisions before considering Spot Instances as your environment scales up. This option is relevant only when enable_spot_instances is true."
 }
 
 variable "spot_fleet_on_demand_above_base_percentage" {
-  type = number
-  default = -1
+  type        = number
+  default     = -1
   description = "The percentage of On-Demand Instances as part of additional capacity that your Auto Scaling group provisions beyond the SpotOnDemandBase instances. This option is relevant only when enable_spot_instances is true."
 }
 
 variable "spot_max_price" {
-  type = number
-  default = -1
+  type        = number
+  default     = -1
   description = "The maximum price per unit hour, in US$, that you're willing to pay for a Spot Instance. This option is relevant only when enable_spot_instances is true. Valid values are between 0.001 and 20.0"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -119,6 +119,30 @@ variable "instance_type" {
   description = "Instances type"
 }
 
+variable "enable_spot_instances" {
+  type = bool
+  default = false
+  description = "Enable Spot Instance requests for your environment"
+}
+
+variable "spot_fleet_on_demand_base" {
+  type = number
+  default = 0
+  description = "The minimum number of On-Demand Instances that your Auto Scaling group provisions before considering Spot Instances as your environment scales up. This option is relevant only when enable_spot_instances is true."
+}
+
+variable "spot_fleet_on_demand_above_base_percentage" {
+  type = number
+  default = -1
+  description = "The percentage of On-Demand Instances as part of additional capacity that your Auto Scaling group provisions beyond the SpotOnDemandBase instances. This option is relevant only when enable_spot_instances is true."
+}
+
+variable "spot_max_price" {
+  type = number
+  default = -1
+  description = "The maximum price per unit hour, in US$, that you're willing to pay for a Spot Instance. This option is relevant only when enable_spot_instances is true. Valid values are between 0.001 and 20.0"
+}
+
 variable "enhanced_reporting_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what
* Allow usage of spot instances in beanstalk environments

## why
* We want to use spot instances in some of our beanstalk environments and this was missing in the module

## references
* `closes #100`

