### PR TITLE
Bring back the SSHSourceRestriction setting.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -558,6 +558,12 @@ resource "aws_elastic_beanstalk_environment" "default" {
   }
 
   setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "SSHSourceRestriction"
+    value     = "tcp,22,22,${var.ssh_source_restriction}"
+  }
+
+  setting {
     namespace = "aws:autoscaling:asg"
     name      = "Availability Zones"
     value     = var.availability_zone_selector


### PR DESCRIPTION
## what
* Bring back the SSHSourceRestriction 

## why
* This got accidentally removed in a previous commit https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/commit/fe6d0d7242dff18928cc204fb3c693e104978b17#diff-7a370d8342e7203b805911c92454f0f4L494

## references
* Open ticket: https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/issues/123

