### PR TITLE
Further Fixes for Setting Issues in  #114

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ Available targets:
 | health\_streaming\_retention\_in\_days | The number of days to keep the archived health data before it expires. | `number` | `7` | no |
 | healthcheck\_url | Application Health Check URL. Elastic Beanstalk will call this URL to check the health of the application running on EC2 instances | `string` | `"/healthcheck"` | no |
 | http\_listener\_enabled | Enable port 80 (http) | `bool` | `true` | no |
+| iam\_instance\_profile | EC2 profile role name | `string` | `"${module.label.id}-eb-ec2"` | no |
+| iam\_service\_role| EB service role name | `string` | `"${module.label.id}-eb-service"` | no |
 | instance\_refresh\_enabled | Enable weekly instance replacement. | `bool` | `true` | no |
 | instance\_type | Instances type | `string` | `"t2.micro"` | no |
 | keypair | Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -676,12 +676,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
     resource  = ""
   }
 
-  setting {
-    namespace = "aws:ec2:instances"
-    name      = "SpotMaxPrice"
-    value     = var.spot_max_price == -1 ? "null" : var.spot_max_price
-    resource  = ""
-  }
+
 
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
@@ -874,6 +869,17 @@ resource "aws_elastic_beanstalk_environment" "default" {
       name      = setting.value.name
       value     = setting.value.value
       resource  = ""
+    }
+  }
+
+  // dynamic needed as "spot max price" should only have a value if it is defined.
+  dynamic "setting" {
+    for_each = var.spot_max_price == -1 ? [] : [var.spot_max_price] 
+    content {
+        namespace = "aws:ec2:instances"
+        name      = "SpotMaxPrice"
+        value     = var.spot_max_price
+        resource  = ""
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "service" {
 }
 
 resource "aws_iam_role" "service" {
-  name               = "${module.label.id}-eb-service"
+  name               = var.iam_service_role
   assume_role_policy = data.aws_iam_policy_document.service.json
 }
 
@@ -294,8 +294,9 @@ data "aws_iam_policy_document" "default" {
   }
 }
 
+
 resource "aws_iam_instance_profile" "ec2" {
-  name = "${module.label.id}-eb-ec2"
+  name = var.iam_instance_profile
   role = aws_iam_role.ec2.name
 }
 

--- a/main.tf
+++ b/main.tf
@@ -546,7 +546,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
-    value = join(",", compact(sort(concat([aws_security_group.default.id], var.additional_security_groups))))    
+    value     = join(",", compact(sort(concat([aws_security_group.default.id], var.additional_security_groups))))
     resource  = ""
   }
 
@@ -874,12 +874,12 @@ resource "aws_elastic_beanstalk_environment" "default" {
 
   // dynamic needed as "spot max price" should only have a value if it is defined.
   dynamic "setting" {
-    for_each = var.spot_max_price == -1 ? [] : [var.spot_max_price] 
+    for_each = var.spot_max_price == -1 ? [] : [var.spot_max_price]
     content {
-        namespace = "aws:ec2:instances"
-        name      = "SpotMaxPrice"
-        value     = var.spot_max_price
-        resource  = ""
+      namespace = "aws:ec2:instances"
+      name      = "SpotMaxPrice"
+      value     = var.spot_max_price
+      resource  = ""
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -546,7 +546,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
-    value     = join(",", compact(concat([aws_security_group.default.id], sort(var.additional_security_groups))))
+    value = join(",", compact(sort(concat([aws_security_group.default.id], var.additional_security_groups))))    
     resource  = ""
   }
 
@@ -659,24 +659,28 @@ resource "aws_elastic_beanstalk_environment" "default" {
     namespace = "aws:ec2:instances"
     name      = "EnableSpot"
     value     = var.enable_spot_instances ? "true" : "false"
+    resource  = ""
   }
 
   setting {
     namespace = "aws:ec2:instances"
     name      = "SpotFleetOnDemandBase"
     value     = var.spot_fleet_on_demand_base
+    resource  = ""
   }
 
   setting {
     namespace = "aws:ec2:instances"
     name      = "SpotFleetOnDemandAboveBasePercentage"
     value     = var.spot_fleet_on_demand_above_base_percentage == -1 ? (var.environment_type == "LoadBalanced" ? 70 : 0) : var.spot_fleet_on_demand_above_base_percentage
+    resource  = ""
   }
 
   setting {
     namespace = "aws:ec2:instances"
     name      = "SpotMaxPrice"
     value     = var.spot_max_price == -1 ? "null" : var.spot_max_price
+    resource  = ""
   }
 
   setting {
@@ -706,6 +710,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
       namespace = "aws:autoscaling:launchconfiguration"
       name      = "ImageId"
       value     = setting.value
+      resource  = ""
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -546,7 +546,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
-    value     = join(",", compact(sort(concat([aws_security_group.default.id], var.additional_security_groups))))
+    value = join(",", compact(sort(concat([aws_security_group.default.id], var.additional_security_groups))))    
     resource  = ""
   }
 
@@ -874,12 +874,12 @@ resource "aws_elastic_beanstalk_environment" "default" {
 
   // dynamic needed as "spot max price" should only have a value if it is defined.
   dynamic "setting" {
-    for_each = var.spot_max_price == -1 ? [] : [var.spot_max_price]
+    for_each = var.spot_max_price == -1 ? [] : [var.spot_max_price] 
     content {
-      namespace = "aws:ec2:instances"
-      name      = "SpotMaxPrice"
-      value     = var.spot_max_price
-      resource  = ""
+        namespace = "aws:ec2:instances"
+        name      = "SpotMaxPrice"
+        value     = var.spot_max_price
+        resource  = ""
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -490,3 +490,15 @@ variable "deployment_timeout" {
   default     = 600
   description = "Number of seconds to wait for an instance to complete executing commands"
 }
+
+variable "iam_instance_profile" {
+  description = "The IAM Instance Profile name used for EC2"
+  type        = string
+  default     = "${module.label.id}-eb-ec2"
+}
+
+variable "iam_service_role" { 
+  description = "The IAM Service Role used for Elastic Beanstalk"
+  type        = string
+  default     =  "${module.label.id}-eb-service"
+}


### PR DESCRIPTION
* spot instance variables and dynamic variables where not covered
* sorting for securitygroups was not enough
* allow defining the service and profile  role names via variables

those two issues resulted in still having terraform plan showing changes
even if no changes were present.

## what
* added resource fix needed for terraform 0.12.x  that is needed due to https://github.com/hashicorp/terraform/issues/22563#issuecomment-548790058

## why
* Fixes left over issues in https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/pull/114 introduced with parallel changes for SpotOn configuration and missing a sort

