### PR TITLE
LB resources only for LoadBalanced env type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -885,11 +885,11 @@ resource "aws_elastic_beanstalk_environment" "default" {
 }
 
 data "aws_elb_service_account" "main" {
-  count = var.tier == "WebServer" ? 1 : 0
+  count = var.tier == "WebServer" && var.environment_type == "LoadBalanced" ? 1 : 0
 }
 
 data "aws_iam_policy_document" "elb_logs" {
-  count = var.tier == "WebServer" ? 1 : 0
+  count = var.tier == "WebServer" && var.environment_type == "LoadBalanced" ? 1 : 0
 
   statement {
     sid = ""
@@ -912,7 +912,7 @@ data "aws_iam_policy_document" "elb_logs" {
 }
 
 resource "aws_s3_bucket" "elb_logs" {
-  count         = var.tier == "WebServer" ? 1 : 0
+  count         = var.tier == "WebServer" && var.environment_type == "LoadBalanced" ? 1 : 0
   bucket        = "${module.label.id}-eb-loadbalancer-logs"
   acl           = "private"
   force_destroy = var.force_destroy


### PR DESCRIPTION
## what
* Do not get data and do not create s3 bucket for elb logs in case of an environment isn't LoadBalanced type

## why
* I use SingleInstance env type and I don't need the s3 bucket for lb logs


