### PR TITLE
Add missing resource attributes to Spot.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -676,7 +676,12 @@ resource "aws_elastic_beanstalk_environment" "default" {
     resource  = ""
   }
 
-
+  setting {
+    namespace = "aws:ec2:instances"
+    name      = "SpotMaxPrice"
+    value     = var.spot_max_price == -1 ? "null" : var.spot_max_price
+    resource  = ""
+  }
 
   setting {
     namespace = "aws:autoscaling:launchconfiguration"

--- a/main.tf
+++ b/main.tf
@@ -679,7 +679,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:ec2:instances"
     name      = "SpotMaxPrice"
-    value     = var.spot_max_price == -1 ? "null" : var.spot_max_price
+    value     = var.spot_max_price == -1 ? "" : var.spot_max_price
     resource  = ""
   }
 


### PR DESCRIPTION
## what
* Four settings relating to EC2 Spot prices (added in #115) were missing an empty `resource` attribute.  This causes `terraform apply` to constantly reapply the configuration, even if no code or Beanstalk config has changed.

## why
* As #43 shows, terraform 0.12.x shows settings changes during `terraform plan` when no changes were done.

## references
* Broken by #115.
* Applies to #43.

