### PR TITLE
Terraform 0.12 setting fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -676,12 +676,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
     resource  = ""
   }
 
-  setting {
-    namespace = "aws:ec2:instances"
-    name      = "SpotMaxPrice"
-    value     = var.spot_max_price == -1 ? "null" : var.spot_max_price
-    resource  = ""
-  }
+
 
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
@@ -874,6 +869,17 @@ resource "aws_elastic_beanstalk_environment" "default" {
       name      = setting.value.name
       value     = setting.value.value
       resource  = ""
+    }
+  }
+
+  // dynamic needed as "spot max price" should only have a value if it is defined.
+  dynamic "setting" {
+    for_each = var.spot_max_price == -1 ? [] : [var.spot_max_price] 
+    content {
+        namespace = "aws:ec2:instances"
+        name      = "SpotMaxPrice"
+        value     = var.spot_max_price
+        resource  = ""
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -546,7 +546,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
-    value = join(",", compact(sort(concat([aws_security_group.default.id], var.additional_security_groups))))    
+    value     = join(",", compact(sort(concat([aws_security_group.default.id], var.additional_security_groups))))
     resource  = ""
   }
 
@@ -874,12 +874,12 @@ resource "aws_elastic_beanstalk_environment" "default" {
 
   // dynamic needed as "spot max price" should only have a value if it is defined.
   dynamic "setting" {
-    for_each = var.spot_max_price == -1 ? [] : [var.spot_max_price] 
+    for_each = var.spot_max_price == -1 ? [] : [var.spot_max_price]
     content {
-        namespace = "aws:ec2:instances"
-        name      = "SpotMaxPrice"
-        value     = var.spot_max_price
-        resource  = ""
+      namespace = "aws:ec2:instances"
+      name      = "SpotMaxPrice"
+      value     = var.spot_max_price
+      resource  = ""
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -546,7 +546,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
-    value     = join(",", compact(concat([aws_security_group.default.id], sort(var.additional_security_groups))))
+    value = join(",", compact(sort(concat([aws_security_group.default.id], var.additional_security_groups))))    
     resource  = ""
   }
 
@@ -659,24 +659,28 @@ resource "aws_elastic_beanstalk_environment" "default" {
     namespace = "aws:ec2:instances"
     name      = "EnableSpot"
     value     = var.enable_spot_instances ? "true" : "false"
+    resource  = ""
   }
 
   setting {
     namespace = "aws:ec2:instances"
     name      = "SpotFleetOnDemandBase"
     value     = var.spot_fleet_on_demand_base
+    resource  = ""
   }
 
   setting {
     namespace = "aws:ec2:instances"
     name      = "SpotFleetOnDemandAboveBasePercentage"
     value     = var.spot_fleet_on_demand_above_base_percentage == -1 ? (var.environment_type == "LoadBalanced" ? 70 : 0) : var.spot_fleet_on_demand_above_base_percentage
+    resource  = ""
   }
 
   setting {
     namespace = "aws:ec2:instances"
     name      = "SpotMaxPrice"
     value     = var.spot_max_price == -1 ? "null" : var.spot_max_price
+    resource  = ""
   }
 
   setting {
@@ -706,6 +710,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
       namespace = "aws:autoscaling:launchconfiguration"
       name      = "ImageId"
       value     = setting.value
+      resource  = ""
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -546,7 +546,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
-    value     = join(",", compact(sort(concat([aws_security_group.default.id], var.additional_security_groups))))
+    value = join(",", compact(sort(concat([aws_security_group.default.id], var.additional_security_groups))))    
     resource  = ""
   }
 
@@ -874,12 +874,12 @@ resource "aws_elastic_beanstalk_environment" "default" {
 
   // dynamic needed as "spot max price" should only have a value if it is defined.
   dynamic "setting" {
-    for_each = var.spot_max_price == -1 ? [] : [var.spot_max_price]
+    for_each = var.spot_max_price == -1 ? [] : [var.spot_max_price] 
     content {
-      namespace = "aws:ec2:instances"
-      name      = "SpotMaxPrice"
-      value     = var.spot_max_price
-      resource  = ""
+        namespace = "aws:ec2:instances"
+        name      = "SpotMaxPrice"
+        value     = var.spot_max_price
+        resource  = ""
     }
   }
 


### PR DESCRIPTION
* spot instance variables and dynamic variables where not covered
* sorting for securitygroups was not enough

those two issues resulted in still having terraform plan showing changes
even if no changes were present.

## what
* added resource fix needed for terraform 0.12.x  that is needed due to https://github.com/hashicorp/terraform/issues/22563#issuecomment-548790058

## why
* Fixes left over issues in https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/pull/114 introduced with parallel changes for SpotOn configuration and missing a sort

