### PR TITLE
Allow to restrict S3 access

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -229,6 +230,7 @@ Available targets:
 | env\_vars | Map of custom ENV variables to be provided to the application running on Elastic Beanstalk, e.g. env\_vars = { DB\_USER = 'admin' DB\_PASS = 'xxxxxx' } | `map(string)` | `{}` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
 | environment\_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time', `updating_min_in_service` must be set to 0, and `loadbalancer_subnets` will be unused (it applies to the ELB, which does not exist in SingleInstance environments) | `string` | `"LoadBalanced"` | no |
+| extended\_ec2\_policy\_document | Extensions or overrides for the IAM role assigned to EC2 instances | `string` | `"{}"` | no |
 | force\_destroy | Force destroy the S3 bucket for load balancer logs | `bool` | `false` | no |
 | health\_streaming\_delete\_on\_terminate | Whether to delete the log group when the environment is terminated. If false, the health data is kept RetentionInDays days. | `bool` | `false` | no |
 | health\_streaming\_enabled | For environments with enhanced health reporting enabled, whether to create a group in CloudWatch Logs for environment health and archive Elastic Beanstalk environment health data. For information about enabling enhanced health, see aws:elasticbeanstalk:healthreporting:system. | `bool` | `false` | no |
@@ -250,6 +252,7 @@ Available targets:
 | managed\_actions\_enabled | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | `bool` | `true` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | `string` | n/a | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | `string` | `""` | no |
+| prefer\_legacy\_ssm\_policy | Whether to use AmazonEC2RoleforSSM (will soon be deprecated) or AmazonSSMManagedInstanceCore policy | `bool` | `true` | no |
 | preferred\_start\_time | Configure a maintenance window for managed actions in UTC | `string` | `"Sun:10:00"` | no |
 | region | AWS region | `string` | n/a | yes |
 | rolling\_update\_enabled | Whether to enable rolling update | `bool` | `true` | no |
@@ -295,6 +298,7 @@ Available targets:
 | tier | The environment tier |
 | triggers | Autoscaling triggers in use by this environment |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -52,6 +53,7 @@
 | env\_vars | Map of custom ENV variables to be provided to the application running on Elastic Beanstalk, e.g. env\_vars = { DB\_USER = 'admin' DB\_PASS = 'xxxxxx' } | `map(string)` | `{}` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
 | environment\_type | Environment type, e.g. 'LoadBalanced' or 'SingleInstance'.  If setting to 'SingleInstance', `rolling_update_type` must be set to 'Time', `updating_min_in_service` must be set to 0, and `loadbalancer_subnets` will be unused (it applies to the ELB, which does not exist in SingleInstance environments) | `string` | `"LoadBalanced"` | no |
+| extended\_ec2\_policy\_document | Extensions or overrides for the IAM role assigned to EC2 instances | `string` | `"{}"` | no |
 | force\_destroy | Force destroy the S3 bucket for load balancer logs | `bool` | `false` | no |
 | health\_streaming\_delete\_on\_terminate | Whether to delete the log group when the environment is terminated. If false, the health data is kept RetentionInDays days. | `bool` | `false` | no |
 | health\_streaming\_enabled | For environments with enhanced health reporting enabled, whether to create a group in CloudWatch Logs for environment health and archive Elastic Beanstalk environment health data. For information about enabling enhanced health, see aws:elasticbeanstalk:healthreporting:system. | `bool` | `false` | no |
@@ -73,6 +75,7 @@
 | managed\_actions\_enabled | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | `bool` | `true` | no |
 | name | Solution name, e.g. 'app' or 'cluster' | `string` | n/a | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | `string` | `""` | no |
+| prefer\_legacy\_ssm\_policy | Whether to use AmazonEC2RoleforSSM (will soon be deprecated) or AmazonSSMManagedInstanceCore policy | `bool` | `true` | no |
 | preferred\_start\_time | Configure a maintenance window for managed actions in UTC | `string` | `"Sun:10:00"` | no |
 | region | AWS region | `string` | n/a | yes |
 | rolling\_update\_enabled | Whether to enable rolling update | `bool` | `true` | no |
@@ -118,3 +121,4 @@
 | tier | The environment tier |
 | triggers | Autoscaling triggers in use by this environment |
 
+<!-- markdownlint-restore -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -103,5 +103,10 @@ module "elastic_beanstalk_environment" {
 data "aws_iam_policy_document" "minimal_s3_permissions" {
   statement {
     sid = "AllowS3OperationsOnElasticBeanstalkBuckets"
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation"
+    ]
+    resources = ["*"]
   }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -95,4 +95,13 @@ module "elastic_beanstalk_environment" {
 
   additional_settings = var.additional_settings
   env_vars            = var.env_vars
+
+  extended_ec2_policy_document = data.aws_iam_policy_document.minimal_s3_permissions.json
+  prefer_legacy_ssm_policy = false
+}
+
+data "aws_iam_policy_document" "minimal_s3_permissions" {
+  statement {
+    sid = "AllowS3OperationsOnElasticBeanstalkBuckets"
+  }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -97,7 +97,7 @@ module "elastic_beanstalk_environment" {
   env_vars            = var.env_vars
 
   extended_ec2_policy_document = data.aws_iam_policy_document.minimal_s3_permissions.json
-  prefer_legacy_ssm_policy = false
+  prefer_legacy_ssm_policy     = false
 }
 
 data "aws_iam_policy_document" "minimal_s3_permissions" {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
     aws  = "~> 2.0"

--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ resource "aws_iam_role_policy_attachment" "worker_tier" {
 
 resource "aws_iam_role_policy_attachment" "ssm_ec2" {
   role       = aws_iam_role.ec2.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  policy_arn = var.prefer_legacy_ssm_policy ? "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM" : "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_iam_role" "ec2" {
 resource "aws_iam_role_policy" "default" {
   name   = "${module.label.id}-eb-default"
   role   = aws_iam_role.ec2.id
-  policy = data.aws_iam_policy_document.default.json
+  policy = data.aws_iam_policy_document.extended.json
 }
 
 resource "aws_iam_role_policy_attachment" "web_tier" {
@@ -292,6 +292,11 @@ data "aws_iam_policy_document" "default" {
 
     effect = "Allow"
   }
+}
+
+data "aws_iam_policy_document" "extended" {
+  source_json   = data.aws_iam_policy_document.default.json
+  override_json = var.extended_ec2_policy_document
 }
 
 resource "aws_iam_instance_profile" "ec2" {

--- a/variables.tf
+++ b/variables.tf
@@ -490,3 +490,9 @@ variable "deployment_timeout" {
   default     = 600
   description = "Number of seconds to wait for an instance to complete executing commands"
 }
+
+variable "extended_ec2_policy_document" {
+  type = string
+  default = "{}"
+  description = "Extensions or overrides for for IAM role assigned to EC2 instances"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -494,7 +494,7 @@ variable "deployment_timeout" {
 variable "extended_ec2_policy_document" {
   type        = string
   default     = "{}"
-  description = "Extensions or overrides for for IAM role assigned to EC2 instances"
+  description = "Extensions or overrides for the IAM role assigned to EC2 instances"
 }
 
 variable "prefer_legacy_ssm_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -496,3 +496,9 @@ variable "extended_ec2_policy_document" {
   default = "{}"
   description = "Extensions or overrides for for IAM role assigned to EC2 instances"
 }
+
+variable "prefer_legacy_ssm_policy" {
+  type = bool
+  default = true
+  description = "Whether to use AmazonEC2RoleforSSM (will soon be deprecated) or AmazonSSMManagedInstanceCore policy"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -492,13 +492,13 @@ variable "deployment_timeout" {
 }
 
 variable "extended_ec2_policy_document" {
-  type = string
-  default = "{}"
+  type        = string
+  default     = "{}"
   description = "Extensions or overrides for for IAM role assigned to EC2 instances"
 }
 
 variable "prefer_legacy_ssm_policy" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Whether to use AmazonEC2RoleforSSM (will soon be deprecated) or AmazonSSMManagedInstanceCore policy"
 }


### PR DESCRIPTION
## what
Adds two variables `extended_ec2_policy_document` and `prefer_legacy_ssm_policy` to be able to control IAM policies attached to EC2 instance roles.

## why
As noted in #75, currently EC2 instances are configured with a role that gives full S3 access. This is undesirable for security reasons.

* `AmazonEC2RoleforSSM` is a managed policy allowing to use SSM features (Session Manager, for example) with EC2 instances and it gives full S3 access.
* There is an inline policy containing a statement with SID `AllowS3OperationsOnElasticBeanstalkBuckets` that also grants full S3 access.

The `prefer_legacy_ssm_policy` variable (when set to `false`) will replace `AmazonEC2RoleforSSM` with `AmazonSSMManagedInstanceCore` which is recommended by AWS: https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-instance-profile.html
By default, it's set to `true` for backward compatibility.

The `extended_ec2_policy_document` variable takes in a JSON that may be used to override existing policy statements as long as a statement has an SID. See `examples/complete/main.tf` for example usage.

## references
closes #75 