### PR TITLE
Set DNS ALIAS instead of CNAME.

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ Available targets:
 | deployment\_ignore\_health\_check | Do not cancel a deployment due to failed health checks | `bool` | `false` | no |
 | deployment\_timeout | Number of seconds to wait for an instance to complete executing commands | `number` | `600` | no |
 | description | Short description of the Environment | `string` | `""` | no |
-| dns\_subdomain | The subdomain to create on Route53 for the EB environment. For the subdomain to be created, the `dns_zone_id` variable must be set as well | `string` | `""` | no |
-| dns\_zone\_id | Route53 parent zone ID. The module will create sub-domain DNS record in the parent zone for the EB environment | `string` | `""` | no |
+| dns\_subdomain | The subdomain to create on Route53 for the EB environment. For the subdomain ALIAS record to be created, the `dns_zone_id` variable must be set as well | `string` | `""` | no |
+| dns\_zone\_id | Route53 parent zone ID. The module will create sub-domain DNS ALIAS record in the parent zone for the EB environment | `string` | `""` | no |
 | elastic\_beanstalk\_application\_name | Elastic Beanstalk application name | `string` | n/a | yes |
 | elb\_scheme | Specify `internal` if you want to create an internal load balancer in your Amazon VPC so that your Elastic Beanstalk application cannot be accessed from outside your Amazon VPC | `string` | `"public"` | no |
 | enable\_log\_publication\_control | Copy the log files for your application's Amazon EC2 instances to the Amazon S3 bucket associated with your application | `bool` | `false` | no |
@@ -254,6 +254,7 @@ Available targets:
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | instance\_refresh\_enabled | Enable weekly instance replacement. | `bool` | `true` | no |
 | instance\_type | Instances type | `string` | `"t2.micro"` | no |
+| ipv6\_enabled | Set to true to enable an AAAA DNS record to be set as well as the A record | `bool` | `false` | no |
 | keypair | Name of SSH key that will be deployed on Elastic Beanstalk and DataPipeline instance. The key should be present in AWS | `string` | `""` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | loadbalancer\_certificate\_arn | Load Balancer SSL certificate ARN. The certificate must be present in AWS Certificate Manager | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -930,12 +930,16 @@ resource "aws_s3_bucket" "elb_logs" {
 }
 
 module "dns_hostname" {
-  source   = "cloudposse/route53-cluster-hostname/aws"
-  version  = "0.10.0"
-  enabled  = var.dns_zone_id != "" && var.tier == "WebServer" ? true : false
-  dns_name = var.dns_subdomain != "" ? var.dns_subdomain : module.this.name
-  zone_id  = var.dns_zone_id
-  records  = [aws_elastic_beanstalk_environment.default.cname]
+  source                 = "cloudposse/route53-alias/aws"
+  version                = "0.10.0"
+  enabled                = var.dns_zone_id != "" && var.tier == "WebServer" ? true : false
+  aliases                = var.dns_subdomain != "" ? [var.dns_subdomain] : [var.name]
+  evaluate_target_health = true
+  ipv6_enabled           = var.ipv6_enabled
+  parent_zone_id         = var.dns_zone_id
+  target_dns_name        = aws_elastic_beanstalk_environment.default.cname
+  target_zone_id         = var.alb_zone_id[var.region]
 
   context = module.this.context
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "hostname" {
-  value       = module.dns_hostname.hostnames[0]
+  value       = module.dns_hostname.hostnames
   description = "DNS hostname"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "hostname" {
-  value       = module.dns_hostname.hostname
+  value       = module.dns_hostname.hostnames[0]
   description = "DNS hostname"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,13 +35,19 @@ variable "loadbalancer_crosszone" {
 variable "dns_zone_id" {
   type        = string
   default     = ""
-  description = "Route53 parent zone ID. The module will create sub-domain DNS record in the parent zone for the EB environment"
+  description = "Route53 parent zone ID. The module will create sub-domain DNS ALIAS record in the parent zone for the EB environment"
 }
 
 variable "dns_subdomain" {
   type        = string
   default     = ""
-  description = "The subdomain to create on Route53 for the EB environment. For the subdomain to be created, the `dns_zone_id` variable must be set as well"
+  description = "The subdomain to create on Route53 for the EB environment. For the subdomain ALIAS record to be created, the `dns_zone_id` variable must be set as well"
+}
+
+variable "ipv6_enabled" {
+  type        = bool
+  default     = false
+  description = "Set to true to enable an AAAA DNS record to be set as well as the A record"
 }
 
 variable "allowed_security_groups" {


### PR DESCRIPTION
## what
* We are switching from using DNS CNAMEs to using AWS DNS ALIAS which produces 'A' resource records.
* Swapping module `cloudposse/terraform-aws-route53-alias` for module `cloudposse/terraform-aws-route53-alias`.
* Supporting the creation of IPv6 AAAA records as well.

## why
* This is best practice for Beanstalk DNS configuration.
* A single DNS request will occur to retrieve the A/AAAA instead of two requests: one to process the CNAME and the other to process the CNAME's target.
* It allows the use of TXT, CAA, or other resource records for the same domain name.

## references
* Closes #134

