### PR TITLE
Allow "resource" field in additional settings

### DIFF
--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -191,6 +191,7 @@ variable "additional_settings" {
     namespace = string
     name      = string
     value     = string
+    resource  = string
   }))
 
   description = "Additional Elastic Beanstalk setttings. For full list of options, see https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html"

--- a/main.tf
+++ b/main.tf
@@ -878,7 +878,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
       namespace = setting.value.namespace
       name      = setting.value.name
       value     = setting.value.value
-      resource  = ""
+      resource  = setting.value.resource
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -421,6 +421,7 @@ variable "ssh_listener_port" {
 variable "additional_settings" {
   type = list(object({
     namespace = string
+    resource  = string
     name      = string
     value     = string
   }))


### PR DESCRIPTION
## what
* Adds the ability to configure the resource (resource_name) of additional beanstalk settings.

## why
* Was required to add time based scaling to our beanstalk instances.

This isn't the best implementation and I'm open to suggestions on how to better do this, however it works. I think to implement a fully correct solution (as this solution requires passing an empty `""` to the resource key on the object) then https://github.com/hashicorp/terraform/issues/19898 needs to land upstream in Terraform.