### PR TITLE
Upgrading from AWS Provider version 2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -941,9 +941,12 @@ resource "aws_s3_bucket" "elb_logs" {
 }
 
 module "dns_hostname" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
-  enabled = var.dns_zone_id != "" && var.tier == "WebServer" ? true : false
-  name    = var.dns_subdomain != "" ? var.dns_subdomain : var.name
-  zone_id = var.dns_zone_id
-  records = [aws_elastic_beanstalk_environment.default.cname]
+  source      = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
+  enabled     = var.dns_zone_id != "" && var.tier == "WebServer" ? true : false
+  dns_name    = var.dns_subdomain != "" ? var.dns_subdomain : var.name
+  zone_id     = var.dns_zone_id
+  records     = [aws_elastic_beanstalk_environment.default.cname]
+  namespace   = module.label.namespace
+  environment = module.label.environment
+  stage       = module.label.stage
 }

--- a/main.tf
+++ b/main.tf
@@ -941,7 +941,7 @@ resource "aws_s3_bucket" "elb_logs" {
 }
 
 module "dns_hostname" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
   enabled = var.dns_zone_id != "" && var.tier == "WebServer" ? true : false
   name    = var.dns_subdomain != "" ? var.dns_subdomain : var.name
   zone_id = var.dns_zone_id

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws  = "~> 2.0"
+    aws  = ">= 2.0"
     null = "~> 2.0"
   }
 }


### PR DESCRIPTION
## what
* Support greater than version 2 of AWS provider

## why
* So that AWS Provider can be upgraded to version 3, the latest version

## references
* Tested by production deployment in Segence systems, running EB app for few weeks now without problems
