### PR TITLE
mfa_delete removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,6 @@ Available targets:
 | root\_volume\_type | The type of the EBS root volume | `string` | `"gp2"` | no |
 | s3\_bucket\_access\_log\_bucket\_name | Name of the S3 bucket where s3 access log will be sent to | `string` | `""` | no |
 | s3\_bucket\_encryption\_enabled | When set to 'true' the resource will have aes256 encryption enabled by default | `bool` | `true` | no |
-| s3\_bucket\_mfa\_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `true` | no |
 | s3\_bucket\_versioning\_enabled | When set to 'true' the s3 origin bucket will have versioning enabled | `bool` | `true` | no |
 | solution\_stack\_name | Elastic Beanstalk stack, e.g. Docker, Go, Node, Java, IIS. For more info, see https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html | `string` | n/a | yes |
 | spot\_fleet\_on\_demand\_above\_base\_percentage | The percentage of On-Demand Instances as part of additional capacity that your Auto Scaling group provisions beyond the SpotOnDemandBase instances. This option is relevant only when enable\_spot\_instances is true. | `number` | `-1` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -89,7 +89,6 @@
 | root\_volume\_type | The type of the EBS root volume | `string` | `"gp2"` | no |
 | s3\_bucket\_access\_log\_bucket\_name | Name of the S3 bucket where s3 access log will be sent to | `string` | `""` | no |
 | s3\_bucket\_encryption\_enabled | When set to 'true' the resource will have aes256 encryption enabled by default | `bool` | `true` | no |
-| s3\_bucket\_mfa\_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `true` | no |
 | s3\_bucket\_versioning\_enabled | When set to 'true' the s3 origin bucket will have versioning enabled | `bool` | `true` | no |
 | solution\_stack\_name | Elastic Beanstalk stack, e.g. Docker, Go, Node, Java, IIS. For more info, see https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html | `string` | n/a | yes |
 | spot\_fleet\_on\_demand\_above\_base\_percentage | The percentage of On-Demand Instances as part of additional capacity that your Auto Scaling group provisions beyond the SpotOnDemandBase instances. This option is relevant only when enable\_spot\_instances is true. | `number` | `-1` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -84,8 +84,6 @@ module "elastic_beanstalk_environment" {
   extended_ec2_policy_document = data.aws_iam_policy_document.minimal_s3_permissions.json
   prefer_legacy_ssm_policy     = false
 
-  s3_bucket_mfa_delete = false
-
   context = module.this.context
 }
 

--- a/main.tf
+++ b/main.tf
@@ -927,6 +927,7 @@ data "aws_iam_policy_document" "elb_logs" {
 resource "aws_s3_bucket" "elb_logs" {
   #bridgecrew:skip=BC_AWS_S3_13:Skipping `Enable S3 Bucket Logging` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
   #bridgecrew:skip=BC_AWS_S3_14:Skipping `Ensure all data stored in the S3 bucket is securely encrypted at rest` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
+  #bridgecrew:skip=CKV_AWS_52:Skipping `Ensure S3 bucket has MFA delete enabled` due to issue in terraform (https://github.com/hashicorp/terraform-provider-aws/issues/629).
   count         = var.tier == "WebServer" && var.environment_type == "LoadBalanced" ? 1 : 0
   bucket        = "${module.this.id}-eb-loadbalancer-logs"
   acl           = "private"
@@ -947,8 +948,7 @@ resource "aws_s3_bucket" "elb_logs" {
   }
 
   versioning {
-    enabled    = var.s3_bucket_versioning_enabled
-    mfa_delete = var.s3_bucket_mfa_delete
+    enabled = var.s3_bucket_versioning_enabled
   }
 
   dynamic "logging" {

--- a/variables.tf
+++ b/variables.tf
@@ -468,12 +468,6 @@ variable "s3_bucket_access_log_bucket_name" {
   description = "Name of the S3 bucket where s3 access log will be sent to"
 }
 
-variable "s3_bucket_mfa_delete" {
-  type        = bool
-  description = "A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 )"
-  default     = true
-}
-
 variable "s3_bucket_versioning_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what
* `mfa_delete` removed
* Bridgecrew check `Ensure S3 bucket has MFA delete enabled` skipped

## why
* Because terraform doesn't support this argument to be toggled (https://github.com/hashicorp/terraform-provider-aws/issues/629).
* To satisfy Bridgecrew compliance scan

## references
* https://github.com/hashicorp/terraform-provider-aws/issues/629

