### PR TITLE
Update service role policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ For a complete example, see [examples/complete](examples/complete)
     application_subnets     = module.subnets.private_subnet_ids
     allowed_security_groups = [module.vpc.vpc_default_security_group_id]
 
+    prefer_legacy_service_policy = false
+
     // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html
     // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.docker
     solution_stack_name = "64bit Amazon Linux 2018.03 v2.12.17 running Docker 18.06.1-ce"

--- a/README.md
+++ b/README.md
@@ -158,8 +158,6 @@ For a complete example, see [examples/complete](examples/complete)
     application_subnets     = module.subnets.private_subnet_ids
     allowed_security_groups = [module.vpc.vpc_default_security_group_id]
 
-    prefer_legacy_service_policy = false
-
     // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html
     // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.docker
     solution_stack_name = "64bit Amazon Linux 2018.03 v2.12.17 running Docker 18.06.1-ce"
@@ -312,6 +310,7 @@ Available targets:
 | managed\_actions\_enabled | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | `bool` | `true` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| prefer\_legacy\_service\_policy | Whether to use AWSElasticBeanstalkService (deprecated) or AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy policy | `bool` | `true` | no |
 | prefer\_legacy\_ssm\_policy | Whether to use AmazonEC2RoleforSSM (will soon be deprecated) or AmazonSSMManagedInstanceCore policy | `bool` | `true` | no |
 | preferred\_start\_time | Configure a maintenance window for managed actions in UTC | `string` | `"Sun:10:00"` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -123,6 +123,8 @@ usage: |-
       application_subnets     = module.subnets.private_subnet_ids
       allowed_security_groups = [module.vpc.vpc_default_security_group_id]
 
+      prefer_legacy_service_policy = false
+
       // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html
       // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.docker
       solution_stack_name = "64bit Amazon Linux 2018.03 v2.12.17 running Docker 18.06.1-ce"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -103,6 +103,7 @@
 | managed\_actions\_enabled | Enable managed platform updates. When you set this to true, you must also specify a `PreferredStartTime` and `UpdateLevel` | `bool` | `true` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| prefer\_legacy\_service\_policy | Whether to use AWSElasticBeanstalkService (deprecated) or AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy policy | `bool` | `true` | no |
 | prefer\_legacy\_ssm\_policy | Whether to use AmazonEC2RoleforSSM (will soon be deprecated) or AmazonSSMManagedInstanceCore policy | `bool` | `true` | no |
 | preferred\_start\_time | Configure a maintenance window for managed actions in UTC | `string` | `"Sun:10:00"` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -83,6 +83,7 @@ module "elastic_beanstalk_environment" {
 
   extended_ec2_policy_document = data.aws_iam_policy_document.minimal_s3_permissions.json
   prefer_legacy_ssm_policy     = false
+  prefer_legacy_service_policy = false
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_iam_role_policy_attachment" "enhanced_health" {
 
 resource "aws_iam_role_policy_attachment" "service" {
   role       = aws_iam_role.service.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService"
+  policy_arn = "arn:aws:iam::aws:policy/AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy"
 }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_iam_role_policy_attachment" "enhanced_health" {
 
 resource "aws_iam_role_policy_attachment" "service" {
   role       = aws_iam_role.service.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy"
+  policy_arn = var.prefer_legacy_service_policy ? "arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService" : "arn:aws:iam::aws:policy/AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy"
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -471,6 +471,12 @@ variable "prefer_legacy_ssm_policy" {
   description = "Whether to use AmazonEC2RoleforSSM (will soon be deprecated) or AmazonSSMManagedInstanceCore policy"
 }
 
+variable "prefer_legacy_service_policy" {
+  type        = bool
+  default     = true
+  description = "Whether to use AWSElasticBeanstalkService (deprecated) or AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy policy"
+}
+
 variable "s3_bucket_access_log_bucket_name" {
   type        = string
   default     = ""


### PR DESCRIPTION
## what
Adds a new variable `prefer_legacy_ssm_policy` to be able to control IAM policy attached to the service role.

## why
As mentioned in #171 , the `AWSElasticBeanstalkService` policy is getting deprecated and AWS recommends to replace it with `AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy`. Since existing environments may still rely on permissions existing in the deprecated policy, the `prefer_legacy_ssm_policy` variable's default value is set to `true` for backward compatibility.

## references
Closes #171 

