### PR TITLE
Allow usage of loadbalancer_type network

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -463,7 +463,7 @@ locals {
     }
   ]
 
-  nlb_settings = [ ]
+  nlb_settings = []
 
   generic_elb_settings = [
     {

--- a/main.tf
+++ b/main.tf
@@ -495,7 +495,7 @@ locals {
 
   # If the tier is "WebServer" add the elb_settings, otherwise exclude them
   elb_settings_iterim = var.tier == "WebServer" ? var.loadbalancer_type == "application" ? concat(local.alb_settings, local.generic_elb_settings) : concat(local.classic_elb_settings, local.generic_elb_settings) : []
-  
+
   # If the loadbalancer type is "network" skip the HealthCheckPath, otherwise include it
   elb_settings_final = var.loadbalancer_type == "network" ? local.elb_settings_iterim : concat(local.elb_settings_iterim, local.alb_elb_settings)
 }


### PR DESCRIPTION
## what
* Skip HealthCheckPath setting in case that `loadbalancer_type == "network"`
* Set default protocol to `TCP` in case that `loadbalancer_type == "network"`

## why
* Specific settings required to support network load balancer, e.g. for use with legacy API Gateway v1 (REST API)

## references
* closes #66 

