### PR TITLE
Add variable to disable S3 eb-loadbalancer-logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -404,6 +404,7 @@ locals {
       value     = "true"
     },
   ]
+  
   alb_defaul_settings = [
     {
       namespace = "aws:elbv2:loadbalancer"
@@ -448,13 +449,13 @@ locals {
   ]
 
   # Only declare AccessLogsS3Bucket if enable_elb_logs = true
-  alb_settings = var.enable_elb_logs ? concat(alb_defaul_settings, [
+  alb_settings = var.enable_elb_logs ? concat(local.alb_defaul_settings, [
     {
       namespace = "aws:elbv2:loadbalancer"
       name      = "AccessLogsS3Bucket"
       value     = join("", sort(aws_s3_bucket.elb_logs.*.id))
     }
-  ]) : alb_defaul_settings
+  ]) : local.alb_defaul_settings
 
   generic_elb_settings = [
     {

--- a/main.tf
+++ b/main.tf
@@ -413,7 +413,7 @@ locals {
     {
       namespace = "aws:elbv2:loadbalancer"
       name      = "AccessLogsS3Enabled"
-      value     = "true"
+      value     = var.enable_elb_logs ? "true" : "false"
     },
     {
       namespace = "aws:elbv2:loadbalancer"
@@ -995,7 +995,7 @@ resource "aws_s3_bucket" "elb_logs" {
   #bridgecrew:skip=BC_AWS_S3_13:Skipping `Enable S3 Bucket Logging` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
   #bridgecrew:skip=BC_AWS_S3_14:Skipping `Ensure all data stored in the S3 bucket is securely encrypted at rest` check until bridgecrew will support dynamic blocks (https://github.com/bridgecrewio/checkov/issues/776).
   #bridgecrew:skip=CKV_AWS_52:Skipping `Ensure S3 bucket has MFA delete enabled` due to issue in terraform (https://github.com/hashicorp/terraform-provider-aws/issues/629).
-  count         = var.tier == "WebServer" && var.environment_type == "LoadBalanced" ? 1 : 0
+  count         = var.enable_elb_logs ? (var.tier == "WebServer" && var.environment_type == "LoadBalanced" ? 1 : 0) : 0
   bucket        = "${module.this.id}-eb-loadbalancer-logs"
   acl           = "private"
   force_destroy = var.force_destroy

--- a/main.tf
+++ b/main.tf
@@ -404,12 +404,7 @@ locals {
       value     = "true"
     },
   ]
-  alb_settings = [
-    {
-      namespace = "aws:elbv2:loadbalancer"
-      name      = "AccessLogsS3Bucket"
-      value     = join("", sort(aws_s3_bucket.elb_logs.*.id))
-    },
+  alb_defaul_settings = [
     {
       namespace = "aws:elbv2:loadbalancer"
       name      = "AccessLogsS3Enabled"
@@ -451,6 +446,15 @@ locals {
       value     = var.loadbalancer_type == "application" ? var.loadbalancer_ssl_policy : ""
     }
   ]
+
+  # Only declare AccessLogsS3Bucket if enable_elb_logs = true
+  alb_settings = var.enable_elb_logs ? concat(alb_defaul_settings, [
+    {
+      namespace = "aws:elbv2:loadbalancer"
+      name      = "AccessLogsS3Bucket"
+      value     = join("", sort(aws_s3_bucket.elb_logs.*.id))
+    }
+  ]) : alb_defaul_settings
 
   generic_elb_settings = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -227,6 +227,12 @@ variable "enable_stream_logs" {
   description = "Whether to create groups in CloudWatch Logs for proxy and deployment logs, and stream logs from each instance in your environment"
 }
 
+variable "enable_elb_logs" {
+  type        = bool
+  default     = true
+  description = "Whether to enable elb logs or not"
+}
+
 variable "logs_delete_on_terminate" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what
* Add a variable `enable_elb_logs` to control whether or not to enable ELB logs, default value is `true`
* If `enable_elb_logs=false` then the resource `aws_s3_bucket.elb_logs` won't be created.

## why
* In some business cases, we don't want to store elb_logs for cost-saving and don't want to maintain it to save our effort for security compliance.
* This pull request will add a bool variable `enable_elb_logs`, default = true

## references
* #152 

