### PR TITLE
added setInstanceProtection permission to default aws iam policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -174,6 +174,7 @@ data "aws_iam_policy_document" "default" {
       "autoscaling:PutScheduledUpdateGroupAction",
       "autoscaling:ResumeProcesses",
       "autoscaling:SetDesiredCapacity",
+      "autoscaling:SetInstanceProtection",
       "autoscaling:SuspendProcesses",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
       "autoscaling:UpdateAutoScalingGroup",


### PR DESCRIPTION
## what
* Add the autoscaling:SetInstanceProtection to the aws iam policy

## why
* We need to protect the instances from scale in when they are processing data and the mentioned permission was missing in the default policy

## references
* https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html#instance-protection


