### PR TITLE
Fix Example dependencies so that it runs

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "vpc" {
   source     = "cloudposse/vpc/aws"
-  version    = "0.25.0"
+  version    = "0.26.1"
   cidr_block = "172.16.0.0/16"
 
   context = module.this.context

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "vpc" {
   source     = "cloudposse/vpc/aws"
-  version    = "0.18.1"
+  version    = "0.25.0"
   cidr_block = "172.16.0.0/16"
 
   context = module.this.context
@@ -12,7 +12,7 @@ module "vpc" {
 
 module "subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.33.0"
+  version              = "0.39.3"
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
   igw_id               = module.vpc.igw_id
@@ -25,14 +25,15 @@ module "subnets" {
 
 module "elastic_beanstalk_application" {
   source      = "cloudposse/elastic-beanstalk-application/aws"
-  version     = "0.8.0"
+  version     = "0.11.0"
   description = "Test elastic_beanstalk_application"
 
   context = module.this.context
 }
 
 module "elastic_beanstalk_environment" {
-  source                     = "../../"
+  source                     = "cloudposse/elastic-beanstalk-environment/aws"
+  version                    = "0.41.0"
   description                = var.description
   region                     = var.region
   availability_zone_selector = var.availability_zone_selector


### PR DESCRIPTION
## what
*  Updated the versions of dependencies in the example so that it works with terraform 1.0

## why
* Previous version returned "deprecated" errors on vpc module. Example didn't run out of the box
* Note that the example works with VPC <=0.25.0. Later version introduce an incompatibility with the call to module.vpc.vpc_default_security_group_id

## references
* None. I just couldn't run the example when I was discovering this project so I fixed it.

