### PR TITLE
feat: Adding root volume IOPS var

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -120,6 +120,7 @@
 | <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |
 | <a name="input_rolling_update_enabled"></a> [rolling\_update\_enabled](#input\_rolling\_update\_enabled) | Whether to enable rolling update | `bool` | `true` | no |
 | <a name="input_rolling_update_type"></a> [rolling\_update\_type](#input\_rolling\_update\_type) | `Health` or `Immutable`. Set it to `Immutable` to apply the configuration change to a fresh group of instances | `string` | `"Health"` | no |
+| <a name="input_root_volume_iops"></a> [root\_volume\_iops](#input\_root\_volume\_iops) | Default IOPS for the root volume | `number` | `""` | no |
 | <a name="input_root_volume_size"></a> [root\_volume\_size](#input\_root\_volume\_size) | The size of the EBS root volume | `number` | `8` | no |
 | <a name="input_root_volume_type"></a> [root\_volume\_type](#input\_root\_volume\_type) | The type of the EBS root volume | `string` | `"gp2"` | no |
 | <a name="input_s3_bucket_access_log_bucket_name"></a> [s3\_bucket\_access\_log\_bucket\_name](#input\_s3\_bucket\_access\_log\_bucket\_name) | Name of the S3 bucket where s3 access log will be sent to | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -706,6 +706,13 @@ resource "aws_elastic_beanstalk_environment" "default" {
     resource  = ""
   }
 
+setting {
+  namespace = "aws:autoscaling:launchconfiguration"
+  name      = "RootVolumeIOPS"
+  value     = var.root_volume_iops
+  resource  = ""
+}
+
   dynamic "setting" {
     for_each = var.ami_id == null ? [] : [var.ami_id]
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -343,7 +343,7 @@ variable "root_volume_type" {
 }
 
 variable "root_volume_iops" {
-  type        = integer
+  type        = number
   default     = ""
   description = "Default IOPS for the root volume"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -342,6 +342,12 @@ variable "root_volume_type" {
   description = "The type of the EBS root volume"
 }
 
+variable "root_volume_iops" {
+  type        = integer
+  default     = ""
+  description = "Default IOPS for the root volume"
+}
+
 variable "autoscale_measure_name" {
   type        = string
   default     = "CPUUtilization"


### PR DESCRIPTION
## what
* Adds the option for RootVolumeIOPS for Elastic Beanstalk. It gives you the option to set your RootVolume IOPS when using GP3
* Defaults to "".


## why
* When using gp3 volume types, the default IOPS set in the original module throw an error

## references
* https://aws.amazon.com/blogs/aws/new-amazon-ebs-gp3-volume-lets-you-provision-performance-separate-from-capacity-and-offers-20-lower-price/
* https://docs.aws.amazon.com/es_en/elasticbeanstalk/latest/dg/command-options-general.html