### PR TITLE
Fix value of cidr_blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ For a complete example, see [examples/complete](examples/complete)
         to_port                  = 65535
         protocol                 = "-1"
         source_security_group_id = [module.vpc.vpc_default_security_group_id]
-        cidr_blocks              = null
+        cidr_blocks              = []
         description              = "Allow all ingress traffic from trusted Security Groups"
       },
     ]

--- a/README.yaml
+++ b/README.yaml
@@ -145,7 +145,7 @@ usage: |-
           to_port                  = 65535
           protocol                 = "-1"
           source_security_group_id = [module.vpc.vpc_default_security_group_id]
-          cidr_blocks              = null
+          cidr_blocks              = []
           description              = "Allow all ingress traffic from trusted Security Groups"
         },
       ]


### PR DESCRIPTION
## what
Fix cidr_blocks value in README

## why
The current value produces `Error: Invalid value for module argument`

## references
The complete example also uses `[]` as value when no cidr_blocks. https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/blob/master/examples/complete/main.tf#L82

