### PR TITLE
Add missing tags to instance_profile

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -295,6 +295,7 @@ data "aws_iam_policy_document" "extended" {
 resource "aws_iam_instance_profile" "ec2" {
   name = "${module.this.id}-eb-ec2"
   role = aws_iam_role.ec2.name
+  tags = module.this.tags  
 }
 
 module "security_group" {


### PR DESCRIPTION
Tags are missing on instance_profile resource.

This MR for adding it.

