### PR TITLE
Fix bug - `dns_zone_id` not available during planning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1158,14 +1158,18 @@ resource "aws_s3_bucket" "elb_logs" {
   }
 }
 
+locals {
+  dns_zone_id = try(var.zone_id[0], tostring(var.zone_id), "")
+}
+
 module "dns_hostname" {
   source  = "cloudposse/route53-cluster-hostname/aws"
   version = "0.12.2"
 
-  enabled = local.enabled && var.dns_zone_id != "" && var.tier == "WebServer" ? true : false
+  enabled = local.enabled && local.dns_zone_id != "" && var.tier == "WebServer" ? true : false
 
   dns_name = var.dns_subdomain != "" ? var.dns_subdomain : module.this.name
-  zone_id  = var.dns_zone_id
+  zone_id  = local.dns_zone_id
   records  = [join("", aws_elastic_beanstalk_environment.default.*.cname)]
 
   context = module.this.context


### PR DESCRIPTION
## what
* `dns_zone_id` now accepts both `string` and `list(string)`

## why
* When spinning up a new EB environment pointing at a Terraform-managed Route 53 hosted zone, an "Invalid Count Argument" error is thrown

## references
* [cloudposse/terraform-aws-elasticache-redis/main.tf#224](https://github.com/cloudposse/terraform-aws-elasticache-redis/blob/4d67f1ad9499394a82e7a0e1a8f76af7c8520115/main.tf#L224) is the source of the fix

