### PR TITLE
Fixed sort function crashing when create_security_group=false

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.2.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.2.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -643,7 +643,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
-    value     = join(",", compact(sort(concat([module.aws_security_group.id], var.associated_security_group_ids))))
+    value     = join(",", compact(sort(concat([module.aws_security_group.id == null ? "" : module.aws_security_group.id], var.associated_security_group_ids))))
     resource  = ""
   }
 


### PR DESCRIPTION
## what
* Default to empty string if `aws_security_group.id` is null. Empty string will then get filtered out by compact().

## why
* Null value caused sort() function to crash, making it impossible to set `create_security_group` to `false`

## references
* https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/issues/216
