### PR TITLE
Bugfix issue with ALB bucket output name and name in general

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
-  enabled   = module.this.enabled
-  partition = join("", data.aws_partition.current[*].partition)
+  enabled                   = module.this.enabled
+  partition                 = join("", data.aws_partition.current[*].partition)
+  s3_bucket_access_log_name = var.s3_bucket_access_log_bucket_name != "" ? var.s3_bucket_access_log_bucket_name : "${module.this.id}-alb-logs-${random_string.elb_logs_suffix.result}"
 }
 
 data "aws_partition" "current" {
@@ -1103,7 +1104,7 @@ module "elb_logs" {
   source             = "cloudposse/lb-s3-bucket/aws"
   version            = "0.19.0"
   enabled            = var.enable_loadbalancer_logs && local.enabled && var.tier == "WebServer" && var.environment_type == "LoadBalanced" && var.loadbalancer_type != "network" && !var.loadbalancer_is_shared ? true : false
-  name               = "${module.this.id}-alb-logs-${random_string.elb_logs_suffix.result}"
+  name               = local.s3_bucket_access_log_name
   force_destroy      = var.force_destroy
   versioning_enabled = var.s3_bucket_versioning_enabled
   context            = module.this.context

--- a/outputs.tf
+++ b/outputs.tf
@@ -84,7 +84,7 @@ output "load_balancers" {
 }
 
 output "load_balancer_log_bucket" {
-  value       = var.enable_loadbalancer_logs ? "${module.this.id}-eb-loadbalancer-logs-${random_string.elb_logs_suffix.result}" : null
+  value       = var.enable_loadbalancer_logs ? local.s3_bucket_access_log_name : null
   description = "Name of bucket where Load Balancer logs are stored (if enabled)"
 }
 


### PR DESCRIPTION
## what

This fixes the issue with the output of the ALB bucket name, it also incorporates the option to manually set the bucket name to make it backward compatible with the previous deployment (what already has the bucket name assigned)

## why

Because it is a bug that is on production code as commented on [here](https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/commit/92c3ba4e23e87653fe53357399901d65881dbb98#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R87)
