### PR TITLE
Fix: add depends_on instance profile for EB env

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1092,6 +1092,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
     }
   }
 
+  depends_on = [aws_iam_instance_profile.ec2]
 }
 
 resource "random_string" "elb_logs_suffix" {


### PR DESCRIPTION
## what

Add `depends_on` in `elastic_beanstalk_environment` 

## why

If instance profile is created after the environment, the creation of this last will failed.

## references

I just encountered the problem;
```
The instance profile my-env-eb-ec2 associated with the environment does not exist.
```
