### PR TITLE
chore: update solution stack name to version 4.5.1 for multiple fixtures

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -62,7 +62,7 @@ elb_scheme = "public"
 
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.docker
-solution_stack_name = "64bit Amazon Linux 2023 v4.0.1 running Python 3.11"
+solution_stack_name = "64bit Amazon Linux 2023 v4.5.1 running Python 3.11"
 
 version_label = ""
 

--- a/examples/nlb/fixtures.us-east-2.tfvars
+++ b/examples/nlb/fixtures.us-east-2.tfvars
@@ -60,7 +60,7 @@ elb_scheme = "public"
 
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.docker
-solution_stack_name = "64bit Amazon Linux 2023 v4.0.1 running Python 3.11"
+solution_stack_name = "64bit Amazon Linux 2023 v4.5.1 running Python 3.11"
 
 version_label = ""
 

--- a/examples/shared-alb/fixtures.us-east-2.tfvars
+++ b/examples/shared-alb/fixtures.us-east-2.tfvars
@@ -58,7 +58,7 @@ autoscale_upper_increment = 1
 
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.docker
-solution_stack_name = "64bit Amazon Linux 2023 v4.0.1 running Python 3.11"
+solution_stack_name = "64bit Amazon Linux 2023 v4.5.1 running Python 3.11"
 
 version_label = ""
 


### PR DESCRIPTION
## what

- Update test fixture to use most recent EB Python 3.11 platform

## why

- Current fixtures have a deprecated value which is no longer supported and causes tests to fail

## references

- None
