### PR TITLE
feat: expose ec2 service role as output

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -62,7 +62,7 @@ elb_scheme = "public"
 
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.docker
-solution_stack_name = "64bit Amazon Linux 2023 v4.0.1 running Python 3.11"
+solution_stack_name = "64bit Amazon Linux 2023 v4.6.2 running Python 3.11"
 
 version_label = ""
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -22,6 +22,7 @@ module "subnets" {
   ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled  = true
   nat_instance_enabled = false
+  max_nats             = 1
 
   context = module.this.context
 }

--- a/examples/nlb/fixtures.us-east-2.tfvars
+++ b/examples/nlb/fixtures.us-east-2.tfvars
@@ -60,7 +60,7 @@ elb_scheme = "public"
 
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.docker
-solution_stack_name = "64bit Amazon Linux 2023 v4.0.1 running Python 3.11"
+solution_stack_name = "64bit Amazon Linux 2023 v4.6.2 running Python 3.11"
 
 version_label = ""
 

--- a/examples/nlb/main.tf
+++ b/examples/nlb/main.tf
@@ -22,6 +22,7 @@ module "subnets" {
   ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled  = true
   nat_instance_enabled = false
+  max_nats             = 1
 
   context = module.this.context
 }

--- a/examples/shared-alb/fixtures.us-east-2.tfvars
+++ b/examples/shared-alb/fixtures.us-east-2.tfvars
@@ -58,7 +58,7 @@ autoscale_upper_increment = 1
 
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html
 // https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.docker
-solution_stack_name = "64bit Amazon Linux 2023 v4.0.1 running Python 3.11"
+solution_stack_name = "64bit Amazon Linux 2023 v4.6.2 running Python 3.11"
 
 version_label = ""
 

--- a/examples/shared-alb/main.tf
+++ b/examples/shared-alb/main.tf
@@ -22,6 +22,7 @@ module "subnets" {
   ipv4_cidr_block      = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled  = true
   nat_instance_enabled = false
+  max_nats             = 1
 
   context = module.this.context
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,6 +38,11 @@ output "ec2_instance_profile_role_name" {
   description = "Instance IAM role name"
 }
 
+output "ec2_service_role_arn" {
+  value       = join("", aws_iam_role.service[*].arn)
+  description = "EC2 service IAM role ARN"
+}
+
 output "tier" {
   value       = join("", aws_elastic_beanstalk_environment.default[*].tier)
   description = "The environment tier"

--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -1,4 +1,4 @@
-export TF_CLI_ARGS_init ?= -get-plugins=true
+export TF_CLI_ARGS_init ?= -upgrade=true
 export TERRAFORM_VERSION ?= $(shell curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version' | cut -d. -f1-2)
 
 .DEFAULT_GOAL : all


### PR DESCRIPTION
## what

* Expose service role, so that it can be used as input for other modules.
* Fix terratest tests for environment creation.

## why

* It can be leveraged in conjunction  of the [Elastic Beanstalk Application](https://github.com/cloudposse/terraform-aws-elastic-beanstalk-application). Since the service role is already created by the EB environment module.
* Fixing Terratest allows reliable automated validation of this module.

## references

* For instance, it can be referred in in the module  [Elastic Beanstalk Application](https://github.com/cloudposse/terraform-aws-elastic-beanstalk-application) `appversion_lifecycle_service_role_arn` as part of [lifecycle role cleanup ](https://github.com/cloudposse/terraform-aws-elastic-beanstalk-application/blob/main/variables.tf#L7)
* Terratest error while testing:
`Error: creating Elastic Beanstalk Environment (eg-test-eb-env-shared-alb-qjkk0y): operation error Elastic Beanstalk: CreateEnvironment, https response error StatusCode: 400, RequestID: f6b66297-8b0d-4902-a3d8-934ffc0c4a32, api error InvalidParameterValue: No Solution Stack named '64bit Amazon Linux 2023 v4.0.1 running Python 3.11'`
